### PR TITLE
[autorelease] Release 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 ## [Unreleased]
 
- - Added Storm Spiral Animation macro - no sounds yet
- - Migrated Storm Spiral from Macro to Action triggered from template hook
- - Added sound to Storm Spiral
- - Cleaned up Rising Hurricane to use some of the targeting utils and removed errors
- - Added sound to Rising Hurricane
- - Added generic template triggering code
- - Change Lightning Dash to use trigger and remove macro
- - Make Lightning Dash stop at walls
+## [0.53.0] - 2025-07-13
+
+- Added Storm Spiral Animation macro - no sounds yet
+- Migrated Storm Spiral from Macro to Action triggered from template hook
+- Added sound to Storm Spiral
+- Cleaned up Rising Hurricane to use some of the targeting utils and removed errors
+- Added sound to Rising Hurricane
+- Added generic template triggering code
+- Change Lightning Dash to use trigger and remove macro
+- Make Lightning Dash stop at walls
 
 ## [0.52.0] - 2025-01-03
 
@@ -26,10 +28,12 @@
 - Notification instructions shown for Dive and Breach
 - Switch to typescript
 
-[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.52.0...HEAD
+[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.53.0...HEAD
+
+[0.53.0]: https://github.com/olilan1/samioli-module/compare/v0.52.0...v0.53.0
 
 [0.52.0]: https://github.com/olilan1/samioli-module/compare/v0.51.0...v0.52.0
 
-[0.51.0]: https://github.com/olilan1/samioli-module/compare/0.50.0...v0.51.0
+[0.51.0]: https://github.com/olilan1/samioli-module/compare/v0.50.0...v0.51.0
 
-[0.50.0]: https://github.com/olilan1/samioli-module/releases/tag/0.50.0
+[0.50.0]: https://github.com/olilan1/samioli-module/releases/tag/v0.50.0


### PR DESCRIPTION
**This PR was created automatically by the releasebot**

**:warning: Approving this PR will trigger a workflow that generates a draft release. You need to publish this release when you are happy with it.**

The changes in this PR prepare for release 0.53.0. The release notes are:

---

- Added Storm Spiral Animation macro - no sounds yet
- Migrated Storm Spiral from Macro to Action triggered from template hook
- Added sound to Storm Spiral
- Cleaned up Rising Hurricane to use some of the targeting utils and removed errors
- Added sound to Rising Hurricane
- Added generic template triggering code
- Change Lightning Dash to use trigger and remove macro
- Make Lightning Dash stop at walls