### PR TITLE
Effects Should only be added/removed by the GM

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -155,6 +155,7 @@ Hooks.on('preDeleteToken', async (token: TokenDocumentPF2e, _action, _id) => {
 
 Hooks.on('moveToken', (token: TokenPF2e, movement, _action, _user: UserPF2e) => {
     hook(addOrRemoveWithinEffectIfNeeded, token, movement.passed.cost)
+        .ifGM()
         .ifEnabled(SETTINGS.AUTO_START_OF_TURN_SPELL_CHECK)
         .run();
     hook(moveGhostlyCarrierToCaster, token, movement.destination.x, movement.destination.y)


### PR DESCRIPTION
Small bug fix from something I noticed last week. Effects shouldn't be added/removed by other players, which is why we were seeing errors but you weren't.