### PR TITLE
[autorelease] Release 0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.61.0] - 2026-04-12
+
 - Fix start of turn spells bug
 - Add macro for weapon shifting
 - Add filtering for weapon shift dialog
@@ -91,7 +93,9 @@
 - Notification instructions shown for Dive and Breach
 - Switch to typescript
 
-[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.60.0...HEAD
+[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.61.0...HEAD
+
+[0.61.0]: https://github.com/olilan1/samioli-module/compare/v0.60.0...v0.61.0
 
 [0.60.0]: https://github.com/olilan1/samioli-module/compare/v0.59.0...v0.60.0
 


### PR DESCRIPTION
**This PR was created automatically by the releasebot**

**:warning: Approving this PR will trigger a workflow that generates a draft release. You need to publish this release when you are happy with it.**

The changes in this PR prepare for release 0.61.0. The release notes are:

---

- Fix start of turn spells bug
- Add macro for weapon shifting
- Add filtering for weapon shift dialog
- Update create sound database script