### PR TITLE
Add consolidation script for beta release changelogs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,6 +46,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Consolidate beta releases
+      if: ${{ !startsWith(github.event.inputs.release-type, 'pre') }}
+      run: node scripts/run-consolidation.js
+
     - name: Update changelog
       id: update-changelog
       uses: release-flow/keep-a-changelog-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Pre-production release handling in changelog
+
 ## [0.63.0] - 2026-05-18
 
 - Dancing Blade automation

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "sequencer": "github:fantasycalendar/FoundryVTT-Sequencer",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.17.0",
-        "vite": "^6.0.3"
+        "vite": "^6.0.3",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -1696,6 +1697,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
@@ -1704,6 +1712,17 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/cors": {
@@ -1720,6 +1739,13 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
       "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2145,6 +2171,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@yaireo/tagify": {
       "version": "4.37.1",
       "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.37.1.tgz",
@@ -2265,6 +2404,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/axobject-query": {
@@ -2402,6 +2551,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2497,6 +2656,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2676,6 +2842,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2914,6 +3087,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2930,6 +3113,16 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3699,6 +3892,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3788,6 +3992,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/peggy": {
       "version": "5.1.0",
@@ -4352,6 +4563,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/socket.io": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
@@ -4449,6 +4667,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4510,6 +4742,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4525,6 +4774,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4728,6 +4987,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -4749,6 +5098,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "pack": "node ./build/pack.mjs"
+    "pack": "node ./build/pack.mjs",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
@@ -17,6 +18,7 @@
     "sequencer": "github:fantasycalendar/FoundryVTT-Sequencer",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.17.0",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^4.1.7"
   }
 }

--- a/scripts/consolidate.d.ts
+++ b/scripts/consolidate.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Consolidates pre-release (beta) changes into the Unreleased section
+ * and removes the pre-release headers and reference links from the changelog.
+ *
+ * @param content - The raw CHANGELOG.md file content.
+ * @param repoUrl - The fallback repository compare URL.
+ * @returns The consolidated changelog content.
+ */
+export function consolidateChangelog(content: string, repoUrl?: string): string;

--- a/scripts/consolidate.js
+++ b/scripts/consolidate.js
@@ -1,0 +1,107 @@
+/**
+ * Consolidates pre-release (beta) changes into the Unreleased section
+ * and removes the pre-release headers and reference links from the changelog.
+ *
+ * @param {string} content - The raw CHANGELOG.md file content.
+ * @param {string} repoUrl - The fallback repository compare URL.
+ * @returns {string} The consolidated changelog content.
+ */
+export function consolidateChangelog(content, repoUrl = 'https://github.com/olilan1/samioli-module/compare/') {
+  // Split content by newline, stripping out carriage returns for cross-platform safety
+  const lines = content.split(/\r?\n/);
+
+  // 1. Find key section boundaries in the changelog
+  const unreleasedIndex = lines.findIndex(line => line.trim() === '## [Unreleased]');
+  if (unreleasedIndex === -1) return content;
+
+  const headerRegex = /^##\s+\[([a-zA-Z0-9.\-+]+)\]/;
+  const firstStableIndex = lines.findIndex((line, idx) => {
+    if (idx <= unreleasedIndex) return false;
+    const match = line.match(headerRegex);
+    return match && match[1].toLowerCase() !== 'unreleased' && !match[1].includes('-');
+  });
+
+  if (firstStableIndex === -1) return content; // Return unmodified if no stable version exists
+
+  const stableVersion = lines[firstStableIndex].match(headerRegex)[1];
+
+  // 2. Identify the pre-release versions we want to consolidate and delete
+  const prereleaseHeaders = new Set();
+  for (let i = unreleasedIndex + 1; i < firstStableIndex; i++) {
+    const match = lines[i].match(headerRegex);
+    if (match) {
+      prereleaseHeaders.add(match[1]);
+    }
+  }
+
+  // 3. Extract all bullet points from the pre-release block
+  const bullets = [];
+  for (let i = unreleasedIndex + 1; i < firstStableIndex; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith('-')) {
+      bullets.push(lines[i]);
+    }
+  }
+
+  // 4. Find the start of the reference links at the bottom
+  const linkRegex = /^\[([a-zA-Z0-9.\-+]+)\]:\s*(.*)/;
+  const firstLinkIndex = lines.findIndex(line => linkRegex.test(line.trim()));
+
+  // 5. Separate the body lines from the link lines
+  let bodyLines;
+  let linkLines;
+  if (firstLinkIndex !== -1) {
+    bodyLines = lines.slice(0, firstLinkIndex);
+    linkLines = lines.slice(firstLinkIndex);
+  } else {
+    bodyLines = lines;
+    linkLines = [];
+  }
+
+  // 6. Construct the new consolidated Unreleased section
+  const newUnreleased = [
+    '## [Unreleased]',
+    '',
+    ...bullets,
+    ''
+  ];
+
+  // 7. Reconstruct the body
+  const introLines = bodyLines.slice(0, unreleasedIndex);
+  const stableLines = bodyLines.slice(firstStableIndex);
+  const newBodyLines = [...introLines, ...newUnreleased, ...stableLines];
+
+  // 8. Clean up and update the reference links
+  let repoCompareBase = repoUrl;
+  const filteredLinks = [];
+
+  for (const line of linkLines) {
+    const match = line.trim().match(linkRegex);
+    if (match) {
+      const version = match[1];
+      const url = match[2];
+
+      if (prereleaseHeaders.has(version)) {
+        continue; // Skip pre-release reference links
+      }
+
+      if (version.toLowerCase() === 'unreleased') {
+        const compareMatch = url.match(/(https:\/\/github\.com\/[^/]+\/[^/]+\/compare\/)/);
+        if (compareMatch) {
+          repoCompareBase = compareMatch[1];
+        }
+        continue; // Skip the old Unreleased link to rewrite it
+      }
+    }
+    filteredLinks.push(line);
+  }
+
+  const newUnreleasedLink = `[Unreleased]: ${repoCompareBase}v${stableVersion}...HEAD`;
+  const finalLinkLines = [newUnreleasedLink, ...filteredLinks];
+
+  // 9. Reconstruct the final file content, joining with standard Unix newlines
+  const finalContent = [...newBodyLines, ...finalLinkLines].join('\n');
+
+  // Clean up duplicate consecutive empty lines to ensure the output is pristine
+  return finalContent.replace(/\n{3,}/g, '\n\n');
+}

--- a/scripts/run-consolidation.js
+++ b/scripts/run-consolidation.js
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Run when issuing a production release after one or more beta releases.
+ * Updates the changelog to consolidate beta changes into the Unreleased section
+ * and remove the beta headers and reference links from the changelog.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import process from 'process';
+import { consolidateChangelog } from './consolidate.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const changelogPath = path.resolve(__dirname, '../CHANGELOG.md');
+
+// Ensure the changelog file exists before attempting to read it
+if (!fs.existsSync(changelogPath)) {
+  console.error('CHANGELOG.md not found.');
+  process.exit(1);
+}
+
+// Read the current file content, execute consolidation, and write changes back if updated
+const fileContent = fs.readFileSync(changelogPath, 'utf8');
+const updated = consolidateChangelog(fileContent);
+
+if (updated !== fileContent) {
+  fs.writeFileSync(changelogPath, updated, 'utf8');
+  console.log('Changelog consolidated successfully.');
+} else {
+  console.log('No pre-releases to consolidate.');
+}

--- a/tests/consolidate.test.ts
+++ b/tests/consolidate.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { consolidateChangelog } from '../scripts/consolidate.js';
+
+describe('Changelog Consolidation Logic', () => {
+  it('should consolidate multiple pre-release sections and clean them up', () => {
+    const mockChangelog = `# Changelog
+
+## [Unreleased]
+
+- Some final tweak
+
+## [0.64.0-beta.1] - 2026-05-20
+
+- Feature B
+- Fix for Feature A
+
+## [0.64.0-beta.0] - 2026-05-18
+
+- Feature A
+
+## [0.63.0] - 2026-05-11
+
+- Dancing Blade automation
+
+[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.64.0-beta.1...HEAD
+[0.64.0-beta.1]: https://github.com/olilan1/samioli-module/compare/v0.64.0-beta.0...v0.64.0-beta.1
+[0.64.0-beta.0]: https://github.com/olilan1/samioli-module/compare/v0.63.0...v0.64.0-beta.0
+[0.63.0]: https://github.com/olilan1/samioli-module/compare/v0.62.0...v0.63.0
+`;
+
+    const expected = `# Changelog
+
+## [Unreleased]
+
+- Some final tweak
+- Feature B
+- Fix for Feature A
+- Feature A
+
+## [0.63.0] - 2026-05-11
+
+- Dancing Blade automation
+
+[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.63.0...HEAD
+[0.63.0]: https://github.com/olilan1/samioli-module/compare/v0.62.0...v0.63.0
+`;
+
+    const result = consolidateChangelog(mockChangelog);
+    expect(result.trim()).toBe(expected.trim());
+  });
+
+  it('should return identical content if no pre-releases exist', () => {
+    const mockChangelog = `# Changelog
+
+## [Unreleased]
+
+- Workaround for turn spells
+
+## [0.63.0] - 2026-05-18
+
+- Dancing Blade automation
+
+[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.63.0...HEAD
+[0.63.0]: https://github.com/olilan1/samioli-module/compare/v0.62.0...v0.63.0
+`;
+
+    const result = consolidateChangelog(mockChangelog);
+    expect(result.trim()).toBe(mockChangelog.trim());
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
This adds handling for beta releases in changelogs.

With this change, if a production release is issued after one or more beta releases, the beta changelogs will be moved into the new production release and removed from the changelog.