### PR TITLE
Emote fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Workaround for start of turn spells not triggering for players when casting from activations tab
 - Typo fixed in Antagonize automation
 - Shifting automation maintains staff trait on weapons when shifting
+- Emote macro fix
 
 ## [0.64.0] - 2026-05-30
 

--- a/macros/emote.js
+++ b/macros/emote.js
@@ -1,21 +1,21 @@
-/* {"name":"Emote","img":"icons/magic/air/weather-clouds.webp"} */
+/* {"name":"Emote","img":"icons/magic/air/weather-clouds.webp","_id":"LdagGQcMGgWGYNg0"} */
 
-if (canvas.tokens.controlled.length !== 1) {
-    ui.notifications.warn("Please select a token");
+const ownedFamiliars = canvas.tokens.placeables.filter(
+    t => t.actor?.type === "familiar" && t.actor?.isOwner
+);
+
+if (ownedFamiliars.length === 0) {
+    ui.notifications.warn("No owned familiar tokens found.");
     return;
 }
 
-const selectedToken = canvas.tokens.controlled[0];
-
-if (selectedToken.actor?.type !== "familiar") {
-    ui.notifications.warn("Please select a familiar token");
+if (ownedFamiliars.length > 1) {
+    ui.notifications.warn(
+        "Multiple owned familiar tokens found. Please ensure only one is on the canvas."
+    );
     return;
 }
 
-if (!selectedToken.actor?.isOwner) {
-    ui.notifications.warn(`You do not have permission to perform an emote with ${selectedToken.name}.`);
-    return;
-}
-
+const tokenToUse = ownedFamiliars[0];
 const myApi = game.modules.get("samioli-module").api;
-myApi.handleEmote(selectedToken);
+myApi.handleEmote(tokenToUse);

--- a/src/actions/emote.ts
+++ b/src/actions/emote.ts
@@ -145,9 +145,7 @@ async function applyMasterMoodEffect(
                     value: bonusValue,
                     type: "circumstance",
                     label: `Aided by ${familiarName}`,
-                    // Currently this removes after any roll
-                    // TODO: See if there's a way to have this only removed after a relevant roll
-                    removeAfterRoll: true
+                    removeAfterRoll: "if-enabled"
                 }
             ]
         }

--- a/tests/macros.test.ts
+++ b/tests/macros.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const macrosDir = path.resolve(__dirname, '../macros');
+
+describe('Macro First Line Format', () => {
+  const files = fs.readdirSync(macrosDir).filter((file) => file.endsWith('.js'));
+
+  it('should find at least one macro', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  files.forEach((file) => {
+    it(`should validate the header comment format for ${file}`, () => {
+      const filePath = path.join(macrosDir, file);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const lines = content.split(/\r?\n/);
+      expect(lines.length).toBeGreaterThan(0);
+
+      const firstLine = lines[0].trim();
+      const match = firstLine.match(/^\/\*\s*(\{.*?\})\s*\*\/$/);
+
+      expect(
+        match,
+        `First line of ${file} must be a block comment /* ... */`
+      ).not.toBeNull();
+
+      let header: Record<string, unknown>;
+      try {
+        header = JSON.parse(match![1]) as Record<string, unknown>;
+      } catch (err) {
+        throw new Error(
+          `First line comment of ${file} does not contain valid JSON: ${match![1]}`
+        );
+      }
+
+      expect(
+        header.name,
+        `Macro "${file}" is missing the mandatory "name" property.`
+      ).toBeTypeOf('string');
+      expect(
+        (header.name as string).length,
+        `Macro "${file}" has an empty "name" property.`
+      ).toBeGreaterThan(0);
+
+      expect(
+        header.img,
+        `Macro "${file}" is missing the mandatory "img" property.`
+      ).toBeTypeOf('string');
+      expect(
+        (header.img as string).length,
+        `Macro "${file}" has an empty "img" property.`
+      ).toBeGreaterThan(0);
+
+      expect(
+        header._id,
+        `Macro "${file}" is missing the mandatory "_id" property.`
+      ).toBeTypeOf('string');
+      expect(
+        header._id as string,
+        `Macro "${file}" "_id" must be exactly 16 characters.`
+      ).toHaveLength(16);
+    });
+  });
+});


### PR DESCRIPTION
- Fix emote macro (missing id)
- Change emote macro to no longer need the familiar to be selected
- Remove aid effect only if it is used
- Add test that macros must have first line with name, icon, id