### PR TITLE
[autorelease] Release 0.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.65.0] - 2026-06-14
+
 - Automated Off guard application for Tumble Behind
 - Updated Sustain Logic to work with Summons
 - Courageous Anthem automation
@@ -122,7 +124,9 @@
 - Notification instructions shown for Dive and Breach
 - Switch to typescript
 
-[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.64.0...HEAD
+[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.65.0...HEAD
+
+[0.65.0]: https://github.com/olilan1/samioli-module/compare/v0.64.0...v0.65.0
 
 [0.64.0]: https://github.com/olilan1/samioli-module/compare/v0.63.0...v0.64.0
 


### PR DESCRIPTION
**This PR was created automatically by the releasebot**

**:warning: Approving this PR will trigger a workflow that generates a draft release. You need to publish this release when you are happy with it.**

The changes in this PR prepare for release 0.65.0. The release notes are:

---

- Automated Off guard application for Tumble Behind
- Updated Sustain Logic to work with Summons
- Courageous Anthem automation
- Automated and Animated Mirror Image
- Workaround for start of turn spells not triggering for players when casting from activations tab
- Typo fixed in Antagonize automation
- Shifting automation maintains staff trait on weapons when shifting
- Emote macro fix