### PR TITLE
Refactor hook runner to allow functions to be called only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- HookRunner refactor
+
 ## [0.65.0] - 2026-06-14
 
 - Automated Off guard application for Tumble Behind

--- a/src/actions/antagonize.ts
+++ b/src/actions/antagonize.ts
@@ -73,7 +73,7 @@ function isAntagonizedByDemoralizer(actorToken: TokenPF2e, demoralizerToken: Tok
     return antagonizedEffects.some(effect => effect.flags.samioli?.antagonizerTokenId === demoralizerToken.id);
 }
 
-export async function createChatMessageOnTurnStartIfTokenIsAntagonized(combatant: CombatantPF2e) {
+export async function postAntagonizedTurnStartMessage(combatant: CombatantPF2e) {
 
     const token = combatant.token?.object;
     if (!token) return;

--- a/src/actions/antagonize.ts
+++ b/src/actions/antagonize.ts
@@ -1,22 +1,10 @@
-import { ActorPF2e, ChatMessagePF2e, CheckContextChatFlag, CombatantPF2e, EffectPF2e, ItemPF2e, TokenPF2e } from "foundry-pf2e"
+import { ActorPF2e, ChatMessagePF2e, CombatantPF2e, EffectPF2e, ItemPF2e, TokenPF2e } from "foundry-pf2e"
 import { getOwnersFromActor, isCondition, sendBasicChatMessage, logd, returnStringOfNamesFromArray } from "../utils.ts";
 import { ImageFilePath } from "foundry-pf2e/foundry/common/constants.mjs";
 
 export async function applyAntagonizeIfValid(chatMessage: ChatMessagePF2e) {
-    const context = chatMessage.flags.pf2e.context as CheckContextChatFlag;
-
-    if (!context?.options?.includes("action:demoralize")) return;
-
-    if (!(context.outcome === "success" || context.outcome === "criticalSuccess")) {
-        return;
-    }
-
     const demoralizer = chatMessage.token?.object;
-
-    if (!demoralizer?.actor?.items.some(item => item.type === "feat" 
-        && item.system.slug === "antagonize")) {
-        return;
-    }
+    if (!demoralizer) return;
 
     const target = chatMessage.target?.token?.object;
     if (!target) return;

--- a/src/actions/enjoytheshow.ts
+++ b/src/actions/enjoytheshow.ts
@@ -22,9 +22,6 @@ export function editEnjoyTheShowSkillRoll(
     }
 }
 
-export async function startEnjoyTheShow(message: ChatMessagePF2e) {
-    animateEnjoyTheShow(message);
-}
 
 function randomRetort(outcome: DegreeOfSuccessString): string {
 
@@ -65,7 +62,7 @@ function checkIfSuccess(outcome: DegreeOfSuccessString): boolean {
         }
 }
 
-async function animateEnjoyTheShow(message: ChatMessagePF2e) {
+export async function startEnjoyTheShow(message: ChatMessagePF2e) {
     const actor = message.actor;
     if (!actor) return;
 

--- a/src/actions/enjoytheshow.ts
+++ b/src/actions/enjoytheshow.ts
@@ -1,31 +1,28 @@
-import { ActorPF2e, ChatMessagePF2e, DegreeOfSuccessString } from "foundry-pf2e";
-import { checkIfProvidesPanache } from "../effects/panache.ts";
+import { ChatMessagePF2e, DegreeOfSuccessString } from "foundry-pf2e";
 import { delay } from "../utils.ts";
 
-export function editEnjoyTheShowSkillRollIfNeeded(
-    chatMessagePF2e: ChatMessagePF2e, html: JQuery<HTMLElement>) {
-    const rollOptions = chatMessagePF2e.flags.pf2e.origin?.rollOptions;
-    if (!rollOptions?.includes("origin:item:slug:enjoy-the-show")) return;
-    editSkillRoll(html, chatMessagePF2e.actor!);
-}
-
-function editSkillRoll(html: JQuery<HTMLElement>, actor: ActorPF2e) {
+export function editEnjoyTheShowSkillRoll(
+    chatMessagePF2e: ChatMessagePF2e,
+    html: JQuery<HTMLElement>
+) {
     html.find('.inline-check.with-repost').attr('data-against', 'will');
     
-    if (actor.items.find(entry => (entry.system.slug === "acrobatic-performer" && entry.type === "feat"))){
+    const actor = chatMessagePF2e.actor;
+    const hasFeat = actor?.items.some(
+        entry => entry.system.slug === "acrobatic-performer" && entry.type === "feat"
+    );
+    if (hasFeat) {
         const elementToClone = html.find('.inline-check.with-repost');
         const clonedElement = elementToClone.clone();
         clonedElement.attr('data-pf2-check', 'acrobatics');
         clonedElement.find('.label').text('Perform with Acrobatics');
-        elementToClone.after(clonedElement)
-        elementToClone.after(' or ') 
+        elementToClone.after(clonedElement);
+        elementToClone.after(' or ');
     }
 }
 
 export async function startEnjoyTheShow(message: ChatMessagePF2e) {
-    if (message.flags.pf2e.context?.options?.includes("item:slug:enjoy-the-show")) {
-        animateEnjoyTheShow(message);
-    }
+    animateEnjoyTheShow(message);
 }
 
 function randomRetort(outcome: DegreeOfSuccessString): string {
@@ -128,7 +125,6 @@ async function animateEnjoyTheShow(message: ChatMessagePF2e) {
         .scale(0.4)
         .opacity(0.5)
         .playIf(checkIfSuccess(outcome))
-    sequence.play()
+    sequence.play();
     await delay(animationTime);
-    checkIfProvidesPanache(message);
 }

--- a/src/actions/enjoytheshow.ts
+++ b/src/actions/enjoytheshow.ts
@@ -1,5 +1,6 @@
 import { ChatMessagePF2e, DegreeOfSuccessString } from "foundry-pf2e";
 import { delay } from "../utils.ts";
+import { applyPanacheForOutcome } from "../effects/panache.ts";
 
 export function editEnjoyTheShowSkillRoll(
     chatMessagePF2e: ChatMessagePF2e,
@@ -65,6 +66,9 @@ function checkIfSuccess(outcome: DegreeOfSuccessString): boolean {
 }
 
 async function animateEnjoyTheShow(message: ChatMessagePF2e) {
+    const actor = message.actor;
+    if (!actor) return;
+
     const tokenId = message.speaker.token;
     const token = canvas.tokens.placeables.find(t => t.id === tokenId);
     const outcome = message.flags.pf2e.context?.outcome;
@@ -127,4 +131,7 @@ async function animateEnjoyTheShow(message: ChatMessagePF2e) {
         .playIf(checkIfSuccess(outcome))
     sequence.play();
     await delay(animationTime);
+    if (outcome === "success" || outcome === "failure" || outcome === "criticalSuccess") {
+        await applyPanacheForOutcome(actor, outcome);
+    }
 }

--- a/src/actions/enjoytheshow.ts
+++ b/src/actions/enjoytheshow.ts
@@ -131,7 +131,14 @@ async function animateEnjoyTheShow(message: ChatMessagePF2e) {
         .playIf(checkIfSuccess(outcome))
     sequence.play();
     await delay(animationTime);
-    if (outcome === "success" || outcome === "failure" || outcome === "criticalSuccess") {
+    const options = message.flags.pf2e.context?.options
+        ?? message.flags.pf2e.origin?.rollOptions
+        ?? [];
+    const hasBravado = options.includes("item:trait:bravado");
+    if (
+        hasBravado &&
+        (outcome === "success" || outcome === "failure" || outcome === "criticalSuccess")
+    ) {
         await applyPanacheForOutcome(actor, outcome);
     }
 }

--- a/src/actions/huntprey.ts
+++ b/src/actions/huntprey.ts
@@ -19,7 +19,8 @@ export async function removeAndApplyHuntPreyAsGM(rangerUuid: string, targetUuids
 }
 
 export async function startHuntPrey(message: ChatMessagePF2e) {
-    const ranger = message.actor!;
+    const ranger = message.actor;
+    if (!ranger) return;
     const targets = message.author?.targets;
 
     if (!targets || targets.size === 0) {

--- a/src/actions/huntprey.ts
+++ b/src/actions/huntprey.ts
@@ -19,13 +19,7 @@ export async function removeAndApplyHuntPreyAsGM(rangerUuid: string, targetUuids
 }
 
 export async function startHuntPrey(message: ChatMessagePF2e) {
-    const ranger = message.actor;
-    if (!ranger) return;
-
-    if (!message.flags?.pf2e?.origin?.rollOptions?.includes("origin:item:hunt-prey")) {
-        return;
-    }
-
+    const ranger = message.actor!;
     const targets = message.author?.targets;
 
     if (!targets || targets.size === 0) {

--- a/src/actions/manifesteidolon.ts
+++ b/src/actions/manifesteidolon.ts
@@ -4,12 +4,9 @@ import { Point } from "foundry-pf2e/foundry/common/_types.mjs";
 import { DEMANIFEST_EIDOLON, getSocket, MANIFEST_EIDOLON } from "../sockets.ts";
 
 export async function manifestEidolon(message: ChatMessagePF2e) {
-
-    if (!message.flags.pf2e.origin?.rollOptions?.includes("origin:item:slug:manifest-eidolon")) return;
-
-    const summonerActor = message.actor;
-    const summonerToken = message.token;
-    if (!summonerActor || !isCharacter(summonerActor) || !summonerToken) return;
+    const summonerActor = message.actor!;
+    const summonerToken = message.token!;
+    if (!isCharacter(summonerActor)) return;
 
     // Find eidolon actor associated with the summoner
     const eidolonActor = getEidolonActor(summonerActor);

--- a/src/actions/manifesteidolon.ts
+++ b/src/actions/manifesteidolon.ts
@@ -4,9 +4,9 @@ import { Point } from "foundry-pf2e/foundry/common/_types.mjs";
 import { DEMANIFEST_EIDOLON, getSocket, MANIFEST_EIDOLON } from "../sockets.ts";
 
 export async function manifestEidolon(message: ChatMessagePF2e) {
-    const summonerActor = message.actor!;
-    const summonerToken = message.token!;
-    if (!isCharacter(summonerActor)) return;
+    const summonerActor = message.actor;
+    const summonerToken = message.token;
+    if (!summonerActor || !isCharacter(summonerActor) || !summonerToken) return;
 
     // Find eidolon actor associated with the summoner
     const eidolonActor = getEidolonActor(summonerActor);

--- a/src/actions/tumblethrough.ts
+++ b/src/actions/tumblethrough.ts
@@ -1,6 +1,7 @@
 import { ChatMessagePF2e, TokenPF2e, EffectSource } from "foundry-pf2e";
 import { delay, logd, addOrUpdateEffectOnActor } from "../utils.ts";
 import { getSetting, SETTINGS } from "../settings.ts";
+import { applyPanacheForOutcome } from "../effects/panache.ts";
 
 const wooshSound1 = "sound/NWN2-Sounds/cb_sw_unarmed04.WAV";
 const wooshSound2 = "sound/NWN2-Sounds/cb_sw_unarmed01.WAV";
@@ -16,6 +17,8 @@ const puffRingAnimation2 = "jb2a.smoke.puff.ring.01.white.1";
 const impactAnimation = "jb2a.impact.008.orange";
 
 export async function startTumbleThrough(chatMessage: ChatMessagePF2e) {
+    const actor = chatMessage.actor;
+    if (!actor) return;
 
     //set up for the animations
     const token = chatMessage.token?.object;
@@ -43,29 +46,45 @@ export async function startTumbleThrough(chatMessage: ChatMessagePF2e) {
 
     const rotationValue = (x < 0) ? -720 : 720
     const context = chatMessage.flags.pf2e.context;
+    const outcome = context?.outcome;
 
     //check if the skillroll was successful
-    if (context?.outcome === "criticalSuccess" || context?.outcome === "success") {
+    if (outcome === "criticalSuccess" || outcome === "success") {
 
         await animateSuccessfulTumble(token, target, rotationValue, x, y);
+        if (outcome === "success" || outcome === "criticalSuccess") {
+            await applyPanacheForOutcome(actor, outcome);
+        }
 
-        const actor = token.actor;
-        const hasTumbleBehind = actor?.itemTypes.feat.some(
-            (feat) => feat.slug === "tumble-behind-rogue" || feat.slug === "tumble-behind-swashbuckler"
+        const tokenActor = token.actor;
+        const hasTumbleBehind = tokenActor?.itemTypes.feat.some(
+            (feat) =>
+                feat.slug === "tumble-behind-rogue" ||
+                feat.slug === "tumble-behind-swashbuckler"
         );
         const autoEnabled = getSetting(SETTINGS.AUTO_TUMBLE_BEHIND);
 
-        if (actor && hasTumbleBehind && autoEnabled) {
+        if (tokenActor && hasTumbleBehind && autoEnabled) {
             await applyTumbleBehindEffect(target, token);
         }
 
-    } else if (chatMessage.flags.pf2e.context?.outcome === "criticalFailure"
-        || chatMessage.flags.pf2e.context?.outcome === "failure") {
+    } else if (outcome === "criticalFailure" || outcome === "failure") {
 
-        await animateFailureTumble(x, y, token, target, rotationValue, originalTokenPositionX, originalTokenPositionY);
+        await animateFailureTumble(
+            x,
+            y,
+            token,
+            target,
+            rotationValue,
+            originalTokenPositionX,
+            originalTokenPositionY
+        );
+        if (outcome === "failure") {
+            await applyPanacheForOutcome(actor, "failure");
+        }
 
     } else {
-        logd(`did you target anyone? ${chatMessage.flags.pf2e.context?.outcome}`)
+        logd(`did you target anyone? ${outcome}`)
     }
 }
 

--- a/src/actions/tumblethrough.ts
+++ b/src/actions/tumblethrough.ts
@@ -1,5 +1,4 @@
 import { ChatMessagePF2e, TokenPF2e, EffectSource } from "foundry-pf2e";
-import { checkIfProvidesPanache } from "../effects/panache.ts";
 import { delay, logd, addOrUpdateEffectOnActor } from "../utils.ts";
 import { getSetting, SETTINGS } from "../settings.ts";
 
@@ -17,12 +16,6 @@ const puffRingAnimation2 = "jb2a.smoke.puff.ring.01.white.1";
 const impactAnimation = "jb2a.impact.008.orange";
 
 export async function startTumbleThrough(chatMessage: ChatMessagePF2e) {
-
-    //check if the skill check was for a tumblethrough
-    const messageOptions = chatMessage.flags.pf2e.context?.options;
-    if (!messageOptions?.includes("action:tumble-through")) {
-        return;
-    }
 
     //set up for the animations
     const token = chatMessage.token?.object;
@@ -56,8 +49,6 @@ export async function startTumbleThrough(chatMessage: ChatMessagePF2e) {
 
         await animateSuccessfulTumble(token, target, rotationValue, x, y);
 
-        checkIfProvidesPanache(chatMessage);
-
         const actor = token.actor;
         const hasTumbleBehind = actor?.itemTypes.feat.some(
             (feat) => feat.slug === "tumble-behind-rogue" || feat.slug === "tumble-behind-swashbuckler"
@@ -72,8 +63,6 @@ export async function startTumbleThrough(chatMessage: ChatMessagePF2e) {
         || chatMessage.flags.pf2e.context?.outcome === "failure") {
 
         await animateFailureTumble(x, y, token, target, rotationValue, originalTokenPositionX, originalTokenPositionY);
-
-        checkIfProvidesPanache(chatMessage);
 
     } else {
         logd(`did you target anyone? ${chatMessage.flags.pf2e.context?.outcome}`)

--- a/src/actions/tumblethrough.ts
+++ b/src/actions/tumblethrough.ts
@@ -47,12 +47,14 @@ export async function startTumbleThrough(chatMessage: ChatMessagePF2e) {
     const rotationValue = (x < 0) ? -720 : 720
     const context = chatMessage.flags.pf2e.context;
     const outcome = context?.outcome;
+    const options = context?.options ?? chatMessage.flags.pf2e.origin?.rollOptions ?? [];
+    const hasBravado = options.includes("item:trait:bravado");
 
     //check if the skillroll was successful
     if (outcome === "criticalSuccess" || outcome === "success") {
 
         await animateSuccessfulTumble(token, target, rotationValue, x, y);
-        if (outcome === "success" || outcome === "criticalSuccess") {
+        if ((outcome === "success" || outcome === "criticalSuccess") && hasBravado) {
             await applyPanacheForOutcome(actor, outcome);
         }
 
@@ -79,7 +81,7 @@ export async function startTumbleThrough(chatMessage: ChatMessagePF2e) {
             originalTokenPositionX,
             originalTokenPositionY
         );
-        if (outcome === "failure") {
+        if (outcome === "failure" && hasBravado) {
             await applyPanacheForOutcome(actor, "failure");
         }
 

--- a/src/chatautobuttons.ts
+++ b/src/chatautobuttons.ts
@@ -127,17 +127,35 @@ const AUTO_SWAP_BUTTONS_CONSUMABLES: Record<string, ButtonSwapSpec> = {
     }
 };
 
+export function canAddAutoButton(message: ChatMessagePF2e): boolean {
+    const rollOptions = message.flags.pf2e?.origin?.rollOptions;
+    if (!rollOptions || !message.token?.object) return false;
+
+    const slug = rollOptions.find(o => o.startsWith(SLUG_PREFIX))?.slice(SLUG_PREFIX.length);
+    const category = rollOptions
+        .find(o => o.startsWith(CATEGORY_PREFIX))
+        ?.slice(CATEGORY_PREFIX.length);
+
+    if (slug) {
+        if (message.flags.pf2e.casting) {
+            if (AUTO_BUTTONS_SPELLS[slug] || AUTO_SWAP_BUTTONS_SPELLS[slug]) return true;
+        }
+        if (AUTO_BUTTONS_ACTIONS[slug]) return true;
+    }
+    if (category) {
+        if (AUTO_SWAP_BUTTONS_CONSUMABLES[category]) return true;
+    }
+    return false;
+}
+
 /**
  * Checks a chat message for specific roll options (slugs or categories) 
  * and triggers the addition or swapping of custom UI buttons on the chat card.
  */
-export function addAutoButtonIfNeeded(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
-    const origin = message.flags.pf2e.origin;
-    const rollOptions = origin?.rollOptions;
-    if (!rollOptions) return;
-
+export function addAutoButtonToMessage(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
+    const rollOptions = message.flags.pf2e.origin?.rollOptions;
     const token = message.token?.object;
-    if (!token) return;
+    if (!rollOptions || !token) return;
 
     const slug = rollOptions.find(item => item.startsWith(SLUG_PREFIX))?.slice(SLUG_PREFIX.length);
     if (slug) {

--- a/src/chatbuttonhelper.ts
+++ b/src/chatbuttonhelper.ts
@@ -71,7 +71,8 @@ export async function createChatMessageWithButton(spec: MessageSpec) {
 }
 
 export function addButtonClickHandlers(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
-    const slug = message.flags[MODULE_ID]!.buttonSlug as string;
+    const slug = message.flags[MODULE_ID]?.buttonSlug as string | undefined;
+    if (!slug) return;
     const funcDesc = BUTTON_FUNCTION_MAPPINGS[slug];
     if (!funcDesc) {
         logd(`Button slug ${slug} has no function mapping.`);

--- a/src/chatbuttonhelper.ts
+++ b/src/chatbuttonhelper.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e, ChatMessagePF2e } from "foundry-pf2e"
-import { getOwnersFromActor, logd } from "./utils.ts";
+import { getOwnersFromActor, logd, MODULE_ID } from "./utils.ts";
 import { removeFrightenedAndAntagonize } from "./effects/frightened.ts";
 import { removeAntagonizeEffect } from "./actions/antagonize.ts";
 import { onClearPanacheButtonClick } from "./effects/panache.ts";
@@ -62,7 +62,7 @@ export async function createChatMessageWithButton(spec: MessageSpec) {
         whisper: spec.gmOnly ? gms : getOwnersFromActor(spec.actor).map(user => user.id),
         speaker: ChatMessage.getSpeaker({ actor: spec.actor }),
         flags: {
-            samioli: {
+            [MODULE_ID]: {
                 buttonSlug: spec.slug,
                 ...spec.flags
             }
@@ -70,9 +70,8 @@ export async function createChatMessageWithButton(spec: MessageSpec) {
     });
 }
 
-export function addButtonClickHandlersIfNeeded(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
-    const slug = message.flags.samioli?.buttonSlug as string | undefined;
-    if (!slug) return;
+export function addButtonClickHandlers(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
+    const slug = message.flags[MODULE_ID]!.buttonSlug as string;
     const funcDesc = BUTTON_FUNCTION_MAPPINGS[slug];
     if (!funcDesc) {
         logd(`Button slug ${slug} has no function mapping.`);

--- a/src/conservationofenergy.ts
+++ b/src/conservationofenergy.ts
@@ -15,26 +15,19 @@ const SPELL_SLUGS = new Set([
     `frostbite`
 ]);
 
-export async function oscillateEnergy(message: ChatMessagePF2e) {
+export function isOscillateSpellCast(message: ChatMessagePF2e): boolean {
     const options = message.flags?.pf2e?.context?.options ?? [];
-    const psychicActor = message.actor as ActorPF2e;
-
-    if (!psychicActor || !options.includes("class:psychic") 
-        || !options.includes("feature:the-oscillating-wave")) {
-        return;
-    }
-
-    // Check if a relevant spell
-    const prefix = "item:";
-    const isRelevantSpell = options.some(o => o.startsWith(prefix) 
-        && SPELL_SLUGS.has(o.substring(prefix.length))
+    const isRelevantSpell = options.some(o =>
+        o.startsWith("item:") && SPELL_SLUGS.has(o.substring("item:".length))
     );
-
-    // Check if mind shift action with add remove energy enabled
     const isMindShiftWithAddRemoveEnergy = options.includes("mindshift:add-remove-energy")
         && options.includes("item:tag:mindshifted");
+    return isRelevantSpell || isMindShiftWithAddRemoveEnergy;
+}
 
-    if (!isRelevantSpell && !isMindShiftWithAddRemoveEnergy) return;
+export async function oscillateEnergy(message: ChatMessagePF2e) {
+    const psychicActor = message.actor as ActorPF2e;
+    if (!psychicActor) return;
 
     // Get the Oscillating Wave Feat
     const oscillatingWaveFeat = psychicActor.itemTypes.feat.find(

--- a/src/effects/panache.ts
+++ b/src/effects/panache.ts
@@ -159,7 +159,9 @@ export function isParryOrBuckleEligible(chatMessage: ChatMessagePF2e): boolean {
   const target = chatMessage.target?.actor;
   if (!context || !target) return false;
 
-  const hasDuelingParry = context.options.includes("target:effect:dueling-parry");
+  const hasDuelingParry =
+    context.options.includes("target:effect:dueling-parry") ||
+    context.options.includes("target:effect:extravagant-parry");
   const hasShieldRaised = context.options.includes("target:effect:raise-a-shield");
   const isFailure = context.outcome === "failure";
   const isCriticalFailure = context.outcome === "criticalFailure";

--- a/src/effects/panache.ts
+++ b/src/effects/panache.ts
@@ -154,22 +154,22 @@ function getPanacheItems(actor: ActorPF2e) {
   return items.filter(item => item.type === "effect" && item.system.slug === "effect-panache");
 }
 
-export function isParryOrBuckleEligible(chatMessage: ChatMessagePF2e): boolean {
+export function isPanacheGeneratingParryOrBuckler(chatMessage: ChatMessagePF2e): boolean {
   const context = chatMessage.flags.pf2e.context;
   const target = chatMessage.target?.actor;
   if (!context || !target) return false;
 
-  const hasDuelingParry =
-    context.options.includes("target:effect:dueling-parry") ||
-    context.options.includes("target:effect:extravagant-parry");
-  const hasShieldRaised = context.options.includes("target:effect:raise-a-shield");
+  const hasExtravagantParry =
+    (context.options?.includes("target:effect:dueling-parry") ||
+    context.options?.includes("target:effect:extravagant-parry")) ?? false;
+  const hasShieldRaised = context.options?.includes("target:effect:raise-a-shield") ?? false;
   const isFailure = context.outcome === "failure";
   const isCriticalFailure = context.outcome === "criticalFailure";
 
   const hasElegantBuckler = hasElegantBucklerFeat(target);
 
   return (
-    (hasDuelingParry && (isFailure || isCriticalFailure)) ||
+    (hasExtravagantParry && (isFailure || isCriticalFailure)) ||
     (hasElegantBuckler && hasShieldRaised && isCriticalFailure)
   );
 }

--- a/src/effects/panache.ts
+++ b/src/effects/panache.ts
@@ -10,13 +10,16 @@ export async function applyPanacheForActor(chatMessage: ChatMessagePF2e) {
     | "criticalSuccess"
     | undefined;
   if (actor && outcome) {
-    await applyPanache(actor, outcome);
+    await applyPanacheForOutcome(actor, outcome);
   }
 }
 
 let isApplyingPanache = false;
 
-async function applyPanache(actor: ActorPF2e, outcome: "success" | "failure" | "criticalSuccess") {
+export async function applyPanacheForOutcome(
+  actor: ActorPF2e,
+  outcome: "success" | "failure" | "criticalSuccess"
+) {
   
   if (isApplyingPanache) {
     return;
@@ -172,7 +175,7 @@ export function isParryOrBuckleEligible(chatMessage: ChatMessagePF2e): boolean {
 export async function applyPanacheForParryOrBuckler(chatMessage: ChatMessagePF2e) {
   const target = chatMessage.target?.actor;
   if (target) {
-    await applyPanache(target, "failure");
+    await applyPanacheForOutcome(target, "failure");
   }
 }
 

--- a/src/effects/panache.ts
+++ b/src/effects/panache.ts
@@ -2,25 +2,15 @@ import { ActorPF2e, ChatMessagePF2e } from "foundry-pf2e";
 import { createChatMessageWithButton } from "../chatbuttonhelper.ts";
 import { logd } from "../utils.ts";
 
-export function checkForBravado(chatMessage: ChatMessagePF2e) {
-  // don't run if tumble through or enjoy the show
-  // those hooks will call this function after the animation
-  if (chatMessage.flags?.pf2e?.context?.options?.includes("item:trait:bravado")
-    && !chatMessage.flags?.pf2e?.context?.options?.includes("action:tumble-through")
-    && !chatMessage.flags?.pf2e?.context?.options?.includes("item:slug:enjoy-the-show")) {
-      checkIfProvidesPanache(chatMessage);
-    }
-}
-  
-export async function checkIfProvidesPanache(chatMessage: ChatMessagePF2e) {
-  const outcome = chatMessage.flags?.pf2e?.context?.outcome;
-  if (chatMessage.flags?.pf2e?.context?.options?.includes("item:trait:bravado") 
-    && (outcome === "criticalSuccess" || outcome === "success" || outcome === "failure")) {
-    const actor = chatMessage.actor;
-    if (!actor) {
-      return;
-    }
-  await applyPanache(actor, outcome);
+export async function applyPanacheForActor(chatMessage: ChatMessagePF2e) {
+  const actor = chatMessage.actor;
+  const outcome = chatMessage.flags.pf2e.context?.outcome as
+    | "success"
+    | "failure"
+    | "criticalSuccess"
+    | undefined;
+  if (actor && outcome) {
+    await applyPanache(actor, outcome);
   }
 }
 
@@ -110,34 +100,22 @@ async function editPanacheEffect(actor: ActorPF2e, outcome: "success" | "failure
   }
 }
 
-export async function checkForFinisherAttack(chatMessage: ChatMessagePF2e) {
-  const context = chatMessage.flags?.pf2e?.context;
-  if (!context?.options?.includes("finisher")) {
-    return;
-  }
+export async function handleFinisherAttack(chatMessage: ChatMessagePF2e) {
   const actor = chatMessage.actor;
-  if (!actor) {
-    return;
-  }
-  
-  if (context?.outcome === "failure" || context?.outcome === "criticalFailure") {
+  if (!actor) return;
+  const outcome = chatMessage.flags.pf2e.context?.outcome;
+  if (outcome === "failure" || outcome === "criticalFailure") {
     await createRemovePanacheChatMessage(actor);
   } else {
     removeDemoralizeImmunity(chatMessage);
   }
 }
 
-export async function checkForFinisherDamage(chatMessage: ChatMessagePF2e) {
-  if (!chatMessage.flags?.pf2e?.context?.options?.includes("finisher")) {
-    return;
-  }
-
+export function clearPanacheForActor(chatMessage: ChatMessagePF2e) {
   const actor = chatMessage.actor;
-  if (!actor) {
-    return;
+  if (actor) {
+    clearPanache(actor);
   }
-
-  clearPanache(actor);
 }
 
 async function createRemovePanacheChatMessage(actor: ActorPF2e) {
@@ -173,35 +151,28 @@ function getPanacheItems(actor: ActorPF2e) {
   return items.filter(item => item.type === "effect" && item.system.slug === "effect-panache");
 }
 
-export async function checkForExtravagantParryOrElegantBuckler(chatMessage: ChatMessagePF2e) {
+export function isParryOrBuckleEligible(chatMessage: ChatMessagePF2e): boolean {
   const context = chatMessage.flags.pf2e.context;
-
-  if (!context || context.type !== "attack-roll" || !context.target?.actor) {
-    return;
-  }
-
-  const targetActorId = context.target.actor.split('.').pop();
-  if (!targetActorId) {
-    return;
-  }
   const target = chatMessage.target?.actor;
-
-  if (!target) {
-    return;
-  }
+  if (!context || !target) return false;
 
   const hasDuelingParry = context.options.includes("target:effect:dueling-parry");
   const hasShieldRaised = context.options.includes("target:effect:raise-a-shield");
   const isFailure = context.outcome === "failure";
   const isCriticalFailure = context.outcome === "criticalFailure";
 
-  const hasElegantBuckler = hasElegantBucklerFeat(target); 
+  const hasElegantBuckler = hasElegantBucklerFeat(target);
 
-  if (
+  return (
     (hasDuelingParry && (isFailure || isCriticalFailure)) ||
     (hasElegantBuckler && hasShieldRaised && isCriticalFailure)
-  ) {
-    applyPanache(target, "failure");
+  );
+}
+
+export async function applyPanacheForParryOrBuckler(chatMessage: ChatMessagePF2e) {
+  const target = chatMessage.target?.actor;
+  if (target) {
+    await applyPanache(target, "failure");
   }
 }
 

--- a/src/effects/unstablecheck.ts
+++ b/src/effects/unstablecheck.ts
@@ -8,16 +8,10 @@ async function applyUnstableEffect(actor: ActorPF2e) {
     await actor.createEmbeddedDocuments("Item", [unstableEffect.toObject()]);
 }
 
-export function checkForUnstableCheck(chatMessage: ChatMessagePF2e) {
-    const context = chatMessage.flags.pf2e.context;
-    if (!context?.options) return;
-    if (context.options.includes("unstable-check") 
-        && context.type === "flat-check"
-        && (context.outcome === "failure" || context.outcome === "criticalFailure" )) {
-        const actorId = context.actor;
-        if (actorId) {
-            const actor = game.actors.get(actorId);
-            if (actor) applyUnstableEffect(actor);
-        }
-    } 
+export function applyUnstableEffectOnFailure(chatMessage: ChatMessagePF2e) {
+    const actorId = chatMessage.flags.pf2e.context?.actor;
+    if (actorId) {
+        const actor = game.actors.get(actorId);
+        if (actor) applyUnstableEffect(actor);
+    }
 }

--- a/src/hookrunner.ts
+++ b/src/hookrunner.ts
@@ -1,0 +1,351 @@
+import { ActorPF2e, ChatMessagePF2e, ItemPF2e, TokenDocumentPF2e } from "foundry-pf2e";
+import { getSetting, SettingsKey } from "./settings.ts";
+
+export function hook<T extends unknown[]>(
+    func: (...args: T) => void,
+    ...args: T
+): HookRunner<T> {
+    return new HookRunner<T>(func, ...args);
+}
+
+function extractTokenDocument(obj: unknown): TokenDocumentPF2e | undefined {
+    if (!obj) return undefined;
+    if ((obj as { documentName?: string }).documentName === "Token") {
+        return obj as TokenDocumentPF2e;
+    }
+    const doc = (obj as { document?: unknown }).document;
+    if (doc && (doc as { documentName?: string }).documentName === "Token") {
+        return doc as TokenDocumentPF2e;
+    }
+    return undefined;
+}
+
+export class HookRunner<T extends unknown[]> {
+    func: (...args: T) => boolean | void;
+    args: T;
+    shouldRun = true;
+    private isGuarded = false;
+
+    constructor(func: (...args: T) => void, ...args: T) {
+        this.func = func;
+        this.args = args;
+    }
+
+    private getActor(): ActorPF2e | undefined {
+        for (const arg of this.args) {
+            if (!arg) continue;
+            if ((arg as { documentName?: string }).documentName === "Actor") {
+                return arg as ActorPF2e;
+            }
+            if ((arg as { actor?: ActorPF2e }).actor) {
+                return (arg as { actor?: ActorPF2e }).actor;
+            }
+        }
+        console.warn(
+            `HookRunner: Could not resolve actor from hook arguments ` +
+            `for function "${this.func.name}".`
+        );
+        return undefined;
+    }
+
+    private getItem(): ItemPF2e | undefined {
+        for (const arg of this.args) {
+            if (!arg) continue;
+            if ((arg as { documentName?: string }).documentName === "Item") {
+                return arg as ItemPF2e;
+            }
+            const item = (arg as { item?: ItemPF2e }).item;
+            if (item?.documentName === "Item") {
+                return item;
+            }
+        }
+        console.warn(
+            `HookRunner: Could not resolve item from hook arguments ` +
+            `for function "${this.func.name}".`
+        );
+        return undefined;
+    }
+
+    private getToken(): TokenDocumentPF2e | undefined {
+        for (const arg of this.args) {
+            if (!arg) continue;
+            const directToken = extractTokenDocument(arg);
+            if (directToken) return directToken;
+
+            const nestedToken = extractTokenDocument((arg as { token?: unknown }).token);
+            if (nestedToken) return nestedToken;
+        }
+        console.warn(
+            `HookRunner: Could not resolve token document from hook arguments ` +
+            `for function "${this.func.name}".`
+        );
+        return undefined;
+    }
+
+    ifEnabled(...settings: SettingsKey[]): this {
+        for (const setting of settings) {
+            if (!getSetting(setting)) {
+                this.shouldRun = false;
+            }
+        }
+        return this;
+    }
+
+    ifGM(): this {
+        if (!game.user.isGM) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessagePoster(): this {
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        if (message && game.user.id !== message.author?.id) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessagePosterAndActorOwner(): this {
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        if (message) {
+            const isAuthor = game.user.id === message.author?.id;
+            const isOwner = !!message.actor?.isOwner;
+            if (!isAuthor || !isOwner) {
+                this.shouldRun = false;
+            }
+        }
+        return this;
+    }
+
+    ifUser(userId: string): this {
+        if (game.user.id !== userId) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifV12(): this {
+        if (!game.version.startsWith("12.")) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    if(predicate: (...args: T) => boolean): this {
+        this.isGuarded = true;
+        if (!predicate(...this.args)) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessageOption(option: string): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        const options = message?.flags.pf2e?.context?.options 
+            ?? message?.flags.pf2e?.origin?.rollOptions;
+        if (!options?.includes(option)) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifNotMessageOption(option: string): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        const options = message?.flags.pf2e?.context?.options 
+            ?? message?.flags.pf2e?.origin?.rollOptions;
+        if (options?.includes(option)) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessageOptionAny(...optionsToCheck: string[]): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        const options = message?.flags.pf2e?.context?.options 
+            ?? message?.flags.pf2e?.origin?.rollOptions;
+        if (!optionsToCheck.some(opt => options?.includes(opt))) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessageItemSlug(slug: string): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        if (message?.item?.slug !== slug) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessageHasTarget(): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        if (!message?.target?.actor) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifTargetHasEffect(effectSlug: string): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        const targetActor = message?.target?.actor;
+        const hasEffect = targetActor?.itemTypes.effect.some(e => e.slug === effectSlug) ?? false;
+        if (!hasEffect) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessageOutcomeIn(...outcomes: string[]): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        const outcome = message?.flags.pf2e?.context?.outcome;
+        if (!outcome || !outcomes.includes(outcome)) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifActorHasFeat(featSlug: string): this {
+        this.isGuarded = true;
+        const actor = this.getActor();
+        const hasFeat = actor?.itemTypes.feat.some(f => f.slug === featSlug) ?? false;
+        if (!hasFeat) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifActorHasEffect(effectSlug: string): this {
+        this.isGuarded = true;
+        const actor = this.getActor();
+        const hasEffect = actor?.items.some(
+            item => item.type === "effect" && item.slug === effectSlug
+        ) ?? false;
+        if (!hasEffect) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifActorHasEffectWithSlugPrefix(prefix: string): this {
+        this.isGuarded = true;
+        const actor = this.getActor();
+        const hasEffect = actor?.items.some(
+            item => item.type === "effect" && (item.slug?.startsWith(prefix) ?? false)
+        ) ?? false;
+        if (!hasEffect) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifActorHasCondition(conditionSlug: string): this {
+        this.isGuarded = true;
+        const actor = this.getActor();
+        const hasCondition = actor?.items.some(
+            item => item.type === "condition" && item.slug === conditionSlug
+        ) ?? false;
+        if (!hasCondition) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifActorHasEffectWithFlag(scope: string, flagName: string): this {
+        this.isGuarded = true;
+        const actor = this.getActor();
+        const hasEffect = actor?.items.some(
+            item => item.type === "effect" && item.getFlag(scope, flagName) !== undefined
+        ) ?? false;
+        if (!hasEffect) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifItemType(type: string): this {
+        this.isGuarded = true;
+        const item = this.getItem();
+        if (item?.type !== type) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifItemSlug(slug: string): this {
+        this.isGuarded = true;
+        const item = this.getItem();
+        if (item?.slug !== slug) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifItemSlugStartsWith(prefix: string): this {
+        this.isGuarded = true;
+        const item = this.getItem();
+        if (!item?.slug?.startsWith(prefix)) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifTokenHasFlag(scope: string, flagName: string): this {
+        this.isGuarded = true;
+        const token = this.getToken();
+        const flagValue = token?.getFlag(scope, flagName);
+        if (flagValue === undefined || flagValue === null || flagValue === "") {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifSceneHasTemplateWithFlag(scope: string, flagName: string): this {
+        this.isGuarded = true;
+        const hasTemplate = canvas.templates?.placeables.some(
+            t => !!t.document.getFlag(scope, flagName)
+        ) ?? false;
+        if (!hasTemplate) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessageHasFlag(scope: string, flagName: string): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        const flags = message?.flags as
+            | Record<string, Record<string, unknown> | undefined>
+            | undefined;
+        if (flags?.[scope]?.[flagName] === undefined) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    allowUnfilteredRun(): this {
+        this.isGuarded = true;
+        return this;
+    }
+
+    run(): boolean | void {
+        if (!this.isGuarded) {
+            throw new Error(
+                `HookRunner: You must add guards to the hook, or call allowUnfilteredRun() ` +
+                `before calling run() for function "${this.func.name}".`
+            );
+        }
+
+        if (this.shouldRun) {
+            return this.func(...this.args);
+        }
+        return false;
+    }
+}

--- a/src/hookrunner.ts
+++ b/src/hookrunner.ts
@@ -1,5 +1,6 @@
 import { ActorPF2e, ChatMessagePF2e, ItemPF2e, TokenDocumentPF2e } from "foundry-pf2e";
 import { getSetting, SettingsKey } from "./settings.ts";
+import { logd } from "./utils.ts";
 
 export function hook<T extends unknown[]>(
     func: (...args: T) => void,
@@ -41,7 +42,7 @@ export class HookRunner<T extends unknown[]> {
                 return (arg as { actor?: ActorPF2e }).actor;
             }
         }
-        console.warn(
+        logd(
             `HookRunner: Could not resolve actor from hook arguments ` +
             `for function "${this.func.name}".`
         );
@@ -59,7 +60,7 @@ export class HookRunner<T extends unknown[]> {
                 return item;
             }
         }
-        console.warn(
+        logd(
             `HookRunner: Could not resolve item from hook arguments ` +
             `for function "${this.func.name}".`
         );
@@ -75,7 +76,7 @@ export class HookRunner<T extends unknown[]> {
             const nestedToken = extractTokenDocument((arg as { token?: unknown }).token);
             if (nestedToken) return nestedToken;
         }
-        console.warn(
+        logd(
             `HookRunner: Could not resolve token document from hook arguments ` +
             `for function "${this.func.name}".`
         );
@@ -127,6 +128,18 @@ export class HookRunner<T extends unknown[]> {
 
     ifV12(): this {
         if (!game.version.startsWith("12.")) {
+            this.shouldRun = false;
+        }
+        return this;
+    }
+
+    ifMessageType(type: string): this {
+        this.isGuarded = true;
+        const message = this.args[0] as ChatMessagePF2e | undefined;
+        const msgType = message?.flags?.pf2e?.context?.type
+            ?? message?.flags?.pf2e?.origin?.type
+            ?? message?.flags?.["samioli-module"]?.type;
+        if (msgType !== type) {
             this.shouldRun = false;
         }
         return this;

--- a/src/hookrunner.ts
+++ b/src/hookrunner.ts
@@ -2,6 +2,20 @@ import { ActorPF2e, ChatMessagePF2e, ItemPF2e, TokenDocumentPF2e } from "foundry
 import { getSetting, SettingsKey } from "./settings.ts";
 import { logd } from "./utils.ts";
 
+/**
+ * Helper function to instantiate a HookRunner builder for registering a hook callback.
+ * 
+ * @template T The type of the arguments passed to the hook.
+ * @param func The hook callback function to run.
+ * @param args Arguments to pass to the hook callback function when executed.
+ * @returns A new HookRunner instance to configure with filters and guards.
+ * 
+ * @example
+ * hook(myCallback, message)
+ *   .ifEnabled(SETTINGS.MY_SETTING)
+ *   .ifGM()
+ *   .run();
+ */
 export function hook<T extends unknown[]>(
     func: (...args: T) => void,
     ...args: T
@@ -9,6 +23,12 @@ export function hook<T extends unknown[]>(
     return new HookRunner<T>(func, ...args);
 }
 
+/**
+ * Extracts a TokenDocumentPF2e from an unknown object, if possible.
+ * 
+ * @param obj The object to inspect.
+ * @returns The resolved TokenDocumentPF2e, or undefined.
+ */
 function extractTokenDocument(obj: unknown): TokenDocumentPF2e | undefined {
     if (!obj) return undefined;
     if ((obj as { documentName?: string }).documentName === "Token") {
@@ -21,17 +41,45 @@ function extractTokenDocument(obj: unknown): TokenDocumentPF2e | undefined {
     return undefined;
 }
 
+/**
+ * Builder class that handles filtering and conditional execution of hook callbacks.
+ * Provides fluent method chaining to enforce configuration settings, actor states,
+ * message states, and user permissions before running a hook function.
+ * 
+ * By default, HookRunner will throw an error if `run()` is called without any filters,
+ * to prevent accidental unfiltered execution. To run a hook, at least one content-specific
+ * filter (e.g. `ifMessageType`, `ifMessageOption`, `ifItemType`) or an explicit call
+ * to `allowUnfilteredRun()` must be chained. General environment checks (like `ifEnabled`,
+ * `ifGM`, `ifUser`) do not count as filters for this purpose.
+ * 
+ * @template T The type of the arguments passed to the hook callback.
+ */
 export class HookRunner<T extends unknown[]> {
     func: (...args: T) => boolean | void;
     args: T;
     shouldRun = true;
     private isGuarded = false;
 
+    /**
+     * Creates an instance of HookRunner.
+     * 
+     * @param func The callback function to execute.
+     * @param args The arguments to pass to the callback function.
+     */
     constructor(func: (...args: T) => void, ...args: T) {
         this.func = func;
         this.args = args;
     }
 
+    /**
+     * Resolves the ActorPF2e document from the hook arguments.
+     * Evaluates arguments sequentially from left to right.
+     * Precedence:
+     * 1. Direct ActorPF2e arguments.
+     * 2. Nested actor properties (e.g. from a TokenDocumentPF2e or ChatMessagePF2e).
+     * 
+     * @returns The resolved ActorPF2e, or undefined if no actor was found in the arguments.
+     */
     private getActor(): ActorPF2e | undefined {
         for (const arg of this.args) {
             if (!arg) continue;
@@ -49,6 +97,15 @@ export class HookRunner<T extends unknown[]> {
         return undefined;
     }
 
+    /**
+     * Resolves the ItemPF2e document from the hook arguments.
+     * Evaluates arguments sequentially from left to right.
+     * Precedence:
+     * 1. Direct ItemPF2e arguments.
+     * 2. Nested item properties (e.g. from a ChatMessagePF2e).
+     * 
+     * @returns The resolved ItemPF2e, or undefined if no item was found in the arguments.
+     */
     private getItem(): ItemPF2e | undefined {
         for (const arg of this.args) {
             if (!arg) continue;
@@ -67,6 +124,15 @@ export class HookRunner<T extends unknown[]> {
         return undefined;
     }
 
+    /**
+     * Resolves the TokenDocumentPF2e document from the hook arguments.
+     * Evaluates arguments sequentially from left to right.
+     * Precedence:
+     * 1. Direct TokenDocumentPF2e arguments (or their internal documents).
+     * 2. Nested token properties.
+     * 
+     * @returns The resolved TokenDocumentPF2e, or undefined if no token was found.
+     */
     private getToken(): TokenDocumentPF2e | undefined {
         for (const arg of this.args) {
             if (!arg) continue;
@@ -83,6 +149,14 @@ export class HookRunner<T extends unknown[]> {
         return undefined;
     }
 
+    /**
+     * Ensures the hook only runs if the specified module settings are active.
+     * 
+     * @note This is a general environment check and does not count as a filter to allow the hook
+     *       to run (a content-specific filter or `allowUnfilteredRun()` must still be called).
+     * @param settings One or more settings keys to verify.
+     * @returns The HookRunner instance for chaining.
+     */
     ifEnabled(...settings: SettingsKey[]): this {
         for (const setting of settings) {
             if (!getSetting(setting)) {
@@ -92,6 +166,15 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts the hook execution to the GM's client only.
+     * Crucial for operations that modify documents (like token movement, template deletion, or
+     * animation placement) to avoid multiple clients executing them concurrently.
+     * 
+     * @note This is a general environment check and does not count as a filter to allow the hook
+     *       to run (a content-specific filter or `allowUnfilteredRun()` must still be called).
+     * @returns The HookRunner instance for chaining.
+     */
     ifGM(): this {
         if (!game.user.isGM) {
             this.shouldRun = false;
@@ -99,6 +182,13 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts the hook execution to the client of the user who posted the chat message.
+     * 
+     * @note This is a general environment check and does not count as a filter to allow the hook
+     *       to run (a content-specific filter or `allowUnfilteredRun()` must still be called).
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessagePoster(): this {
         const message = this.args[0] as ChatMessagePF2e | undefined;
         if (message && game.user.id !== message.author?.id) {
@@ -107,6 +197,14 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to the client of the user who is both the message author and the owner
+     * of the message's associated actor.
+     * 
+     * @note This is a general environment check and does not count as a filter to allow the hook
+     *       to run (a content-specific filter or `allowUnfilteredRun()` must still be called).
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessagePosterAndActorOwner(): this {
         const message = this.args[0] as ChatMessagePF2e | undefined;
         if (message) {
@@ -119,6 +217,14 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to a specific user ID.
+     * 
+     * @note This is a general environment check and does not count as a filter to allow the hook
+     *       to run (a content-specific filter or `allowUnfilteredRun()` must still be called).
+     * @param userId The ID of the user allowed to run the hook.
+     * @returns The HookRunner instance for chaining.
+     */
     ifUser(userId: string): this {
         if (game.user.id !== userId) {
             this.shouldRun = false;
@@ -126,6 +232,13 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to Foundry VTT version 12 environments only.
+     * 
+     * @note This is a general environment check and does not count as a filter to allow the hook
+     *       to run (a content-specific filter or `allowUnfilteredRun()` must still be called).
+     * @returns The HookRunner instance for chaining.
+     */
     ifV12(): this {
         if (!game.version.startsWith("12.")) {
             this.shouldRun = false;
@@ -133,6 +246,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to a specific type of chat message (e.g. "attack-roll", "damage-roll").
+     * 
+     * @param type The chat message context/origin type to check.
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessageType(type: string): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -145,6 +264,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Allows custom filtering logic by running a predicate function on the hook arguments.
+     * 
+     * @param predicate A callback function returning boolean.
+     * @returns The HookRunner instance for chaining.
+     */
     if(predicate: (...args: T) => boolean): this {
         this.isGuarded = true;
         if (!predicate(...this.args)) {
@@ -153,6 +278,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to chat messages that include the specified roll option.
+     * 
+     * @param option The roll option string to check for.
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessageOption(option: string): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -164,6 +295,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to chat messages that do NOT include the specified roll option.
+     * 
+     * @param option The roll option string to check for exclusion.
+     * @returns The HookRunner instance for chaining.
+     */
     ifNotMessageOption(option: string): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -175,6 +312,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to chat messages that contain at least one of the specified roll options.
+     * 
+     * @param optionsToCheck Roll option strings to check for.
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessageOptionAny(...optionsToCheck: string[]): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -186,6 +329,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to chat messages generated from an item matching the specified slug.
+     * 
+     * @param slug The item slug to verify.
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessageItemSlug(slug: string): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -195,6 +344,11 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to chat messages containing a valid target actor.
+     * 
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessageHasTarget(): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -204,6 +358,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to chat messages whose target actor possesses the specified active effect.
+     * 
+     * @param effectSlug The slug of the active effect.
+     * @returns The HookRunner instance for chaining.
+     */
     ifTargetHasEffect(effectSlug: string): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -215,6 +375,13 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to chat messages whose roll outcome matches one of the specified values
+     * (e.g. "success", "failure", "criticalFailure").
+     * 
+     * @param outcomes The roll outcomes that allow execution.
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessageOutcomeIn(...outcomes: string[]): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -225,6 +392,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an actor who has the specified feat.
+     * 
+     * @param featSlug The slug of the feat.
+     * @returns The HookRunner instance for chaining.
+     */
     ifActorHasFeat(featSlug: string): this {
         this.isGuarded = true;
         const actor = this.getActor();
@@ -235,6 +408,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an actor who has the specified active effect.
+     * 
+     * @param effectSlug The slug of the active effect.
+     * @returns The HookRunner instance for chaining.
+     */
     ifActorHasEffect(effectSlug: string): this {
         this.isGuarded = true;
         const actor = this.getActor();
@@ -247,6 +426,13 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an actor who has an active effect starting
+     * with the specified prefix.
+     * 
+     * @param prefix The prefix string of the active effect slug.
+     * @returns The HookRunner instance for chaining.
+     */
     ifActorHasEffectWithSlugPrefix(prefix: string): this {
         this.isGuarded = true;
         const actor = this.getActor();
@@ -259,6 +445,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an actor who has the specified condition.
+     * 
+     * @param conditionSlug The slug of the condition (e.g. "frightened").
+     * @returns The HookRunner instance for chaining.
+     */
     ifActorHasCondition(conditionSlug: string): this {
         this.isGuarded = true;
         const actor = this.getActor();
@@ -271,6 +463,14 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an actor who has an active effect carrying
+     * the specified module flag.
+     * 
+     * @param scope The flag scope namespace.
+     * @param flagName The name of the flag to check.
+     * @returns The HookRunner instance for chaining.
+     */
     ifActorHasEffectWithFlag(scope: string, flagName: string): this {
         this.isGuarded = true;
         const actor = this.getActor();
@@ -283,6 +483,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an item of the specified document type.
+     * 
+     * @param type The document type of the item (e.g., "effect").
+     * @returns The HookRunner instance for chaining.
+     */
     ifItemType(type: string): this {
         this.isGuarded = true;
         const item = this.getItem();
@@ -292,6 +498,12 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an item with the specified slug.
+     * 
+     * @param slug The slug of the item.
+     * @returns The HookRunner instance for chaining.
+     */
     ifItemSlug(slug: string): this {
         this.isGuarded = true;
         const item = this.getItem();
@@ -301,6 +513,13 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing an item whose slug starts with the
+     * specified prefix.
+     * 
+     * @param prefix The prefix string of the item slug.
+     * @returns The HookRunner instance for chaining.
+     */
     ifItemSlugStartsWith(prefix: string): this {
         this.isGuarded = true;
         const item = this.getItem();
@@ -310,6 +529,13 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing a token that carries the specified flag.
+     * 
+     * @param scope The flag scope namespace.
+     * @param flagName The name of the flag.
+     * @returns The HookRunner instance for chaining.
+     */
     ifTokenHasFlag(scope: string, flagName: string): this {
         this.isGuarded = true;
         const token = this.getToken();
@@ -320,6 +546,14 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to scenes that contain at least one measured template carrying the
+     * specified flag.
+     * 
+     * @param scope The flag scope namespace.
+     * @param flagName The name of the flag.
+     * @returns The HookRunner instance for chaining.
+     */
     ifSceneHasTemplateWithFlag(scope: string, flagName: string): this {
         this.isGuarded = true;
         const hasTemplate = canvas.templates?.placeables.some(
@@ -331,6 +565,13 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Restricts execution to hook arguments containing a chat message carrying the specified flag.
+     * 
+     * @param scope The flag scope namespace.
+     * @param flagName The name of the flag.
+     * @returns The HookRunner instance for chaining.
+     */
     ifMessageHasFlag(scope: string, flagName: string): this {
         this.isGuarded = true;
         const message = this.args[0] as ChatMessagePF2e | undefined;
@@ -343,11 +584,24 @@ export class HookRunner<T extends unknown[]> {
         return this;
     }
 
+    /**
+     * Safety bypass to mark a hook as explicitly allowed to run without any conditional filters.
+     * Prevents the internal safety check from throwing an error.
+     * 
+     * @returns The HookRunner instance for chaining.
+     */
     allowUnfilteredRun(): this {
         this.isGuarded = true;
         return this;
     }
 
+    /**
+     * Executes the registered hook callback function if all filters and guards passed.
+     * 
+     * @returns The result of the callback function, or false if bypassed.
+     * @throws {Error} If no safety filters or allowUnfilteredRun() were called on the builder
+     *                 before running.
+     */
     run(): boolean | void {
         if (!this.isGuarded) {
             throw new Error(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -327,11 +327,11 @@ function getMessageType(message: ChatMessagePF2e) {
         ?? message.flags?.[MODULE_ID]?.type;
 }
 
-function hook<T extends unknown[]>(func: (...args: T) => void, ...args: T): HookRunner<T> {
+export function hook<T extends unknown[]>(func: (...args: T) => void, ...args: T): HookRunner<T> {
     return new HookRunner<T>(func, ...args);
 }
 
-class HookRunner<T extends unknown[]> {
+export class HookRunner<T extends unknown[]> {
     func: (...args: T) => boolean | void;
     args: T;
     shouldRun: boolean;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -54,7 +54,6 @@ import {
     deleteWithinEffectsForTemplate,
     addEffectsToTokensInStartOfTurnTemplates,
     addOrRemoveWithinEffectIfNeeded,
-    START_OF_TURN_SPELLS,
     isStartOfTurnSpellTemplate,
     hasStartOfTurnFlags
 } from "./startofturnspells.ts";

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -323,7 +323,7 @@ function handleChatMessageWithRoll(message: ChatMessagePF2e) {
         case "attack-roll":
             hook(startImaginaryWeapon, message)
                 .ifMessagePosterAndActorOwner()
-                .ifMessageItemSlug("imaginary-weapon")
+                .ifMessageOption("item:imaginary-weapon")
                 .run();
             break;
         case "damage-roll":

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,7 +7,7 @@ import {
     applyPanacheForParryOrBuckler,
     handleFinisherAttack,
     clearPanacheForActor,
-    isParryOrBuckleEligible
+    isPanacheGeneratingParryOrBuckler
 } from "./effects/panache.ts";
 import { startHuntPrey } from "./actions/huntprey.ts";
 import {
@@ -39,7 +39,8 @@ import {
     associateTemplateWithSustainedEffect,
     handleSustainedEffectDeletion,
     createSpellNotSustainedChatMessage,
-    isAutomaticSustainSpell
+    isAutomaticSustainSpell,
+    hasSustainingEffect
 } from "./sustain.ts";
 import {
     applyAntagonizeIfValid,
@@ -53,7 +54,9 @@ import {
     deleteWithinEffectsForTemplate,
     addEffectsToTokensInStartOfTurnTemplates,
     addOrRemoveWithinEffectIfNeeded,
-    START_OF_TURN_SPELLS
+    START_OF_TURN_SPELLS,
+    isStartOfTurnSpellTemplate,
+    hasStartOfTurnFlags
 } from "./startofturnspells.ts";
 import ChatLog from "foundry-pf2e/foundry/client/applications/sidebar/tabs/chat.mjs";
 import { addDamageHelperButtonToChatUIv12, addDamageHelperButtonToChatUIv13 } from "./damagehelper.ts";
@@ -141,18 +144,13 @@ Hooks.on("createMeasuredTemplate", async (
     hook(associateTemplateWithSustainedEffect, template)
         .ifEnabled(SETTINGS.AUTO_SUSTAIN_CHECK)
         .ifGM()
-        .if(() => template.actor?.items.some(
-            i => i.type === "effect" && (i.slug?.startsWith("sustaining-effect-") ?? false)
-        ) ?? false)
+        .if(hasSustainingEffect)
         .run();
 
     hook(addEffectsToTokensInStartOfTurnTemplates, template)
         .ifEnabled(SETTINGS.AUTO_START_OF_TURN_SPELL_CHECK)
         .ifGM()
-        .if(() => {
-            const slug = (template.flags.pf2e?.origin as { slug?: string } | undefined)?.slug;
-            return !!slug && START_OF_TURN_SPELLS.includes(slug);
-        })
+        .if(isStartOfTurnSpellTemplate)
         .run();
 });
 
@@ -180,8 +178,7 @@ Hooks.on("deleteMeasuredTemplate", (template: MeasuredTemplateDocumentPF2e) => {
     hook(deleteWithinEffectsForTemplate, template)
         .ifEnabled(SETTINGS.AUTO_START_OF_TURN_SPELL_CHECK)
         .ifGM()
-        .if(() => !!template.getFlag("samioli-module", "startOfTurnEffectUuid")
-            || !!template.getFlag("samioli-module", "spellSource"))
+        .if(hasStartOfTurnFlags)
         .run();
 });
 
@@ -348,7 +345,7 @@ function handleChatMessagePostRoll(message: ChatMessagePF2e) {
                 .ifEnabled(SETTINGS.AUTO_PANACHE)
                 .ifGM()
                 .ifMessageHasTarget()
-                .if(() => isParryOrBuckleEligible(message))
+                .if(() => isPanacheGeneratingParryOrBuckler(message))
                 .run();
             hook(handleFinisherAttack, message)
                 .ifEnabled(SETTINGS.AUTO_PANACHE)

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -110,6 +110,7 @@ Hooks.on("renderChatMessage", async (message: ChatMessagePF2e, html: JQuery<HTML
         .ifMessageOptionAny("origin:item:trait:unstable", "self:action:trait:unstable")
         .run();
     hook(addDancingBladeDamageButtons, message, html)
+        .ifMessageType("attack-roll")
         .ifMessageOption("samioli-module:dancing-blade-attack")
         .run();
 });
@@ -426,12 +427,12 @@ function handleChatMessagePostRoll(message: ChatMessagePF2e) {
             hook(startHuntPrey, message)
                 .ifEnabled(SETTINGS.AUTO_HUNT_PREY)
                 .ifMessagePosterAndActorOwner()
-                .ifMessageItemSlug("hunt-prey")
+                .ifMessageOption("origin:item:hunt-prey")
                 .run();
             hook(manifestEidolon, message)
                 .ifEnabled(SETTINGS.AUTO_MANIFEST_EIDOLON)
                 .ifMessagePosterAndActorOwner()
-                .ifMessageItemSlug("manifest-eidolon")
+                .ifMessageOption("origin:item:slug:manifest-eidolon")
                 .run();
             break;
         case "spell":
@@ -444,7 +445,7 @@ function handleChatMessagePostRoll(message: ChatMessagePF2e) {
             hook(runBoostEidolonAutomation, message)
                 .ifEnabled(SETTINGS.AUTO_BOOST_EIDOLON)
                 .ifMessagePosterAndActorOwner()
-                .ifMessageItemSlug("boost-eidolon")
+                .ifMessageOption("origin:item:slug:boost-eidolon")
                 .run();
             break;
         case "mirror-image-roll":

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,18 +1,60 @@
-import { registerSettings, getSetting, SETTINGS, SettingsKey } from "./settings.ts"
-import { addAutoButtonIfNeeded } from "./chatautobuttons.ts";
+import { registerSettings, SETTINGS } from "./settings.ts";
+import { addAutoButtonToMessage, canAddAutoButton } from "./chatautobuttons.ts";
 import { startTumbleThrough } from "./actions/tumblethrough.ts";
-import { editEnjoyTheShowSkillRollIfNeeded, startEnjoyTheShow } from "./actions/enjoytheshow.ts";
-import { checkForBravado, checkForExtravagantParryOrElegantBuckler, checkForFinisherAttack, checkForFinisherDamage } from "./effects/panache.ts";
+import { editEnjoyTheShowSkillRoll, startEnjoyTheShow } from "./actions/enjoytheshow.ts";
+import {
+    applyPanacheForActor,
+    applyPanacheForParryOrBuckler,
+    handleFinisherAttack,
+    clearPanacheForActor,
+    isParryOrBuckleEligible
+} from "./effects/panache.ts";
 import { startHuntPrey } from "./actions/huntprey.ts";
-import { targetTokensUnderTemplate, deleteTemplateTargets, setTemplateColorToBlack } from "./templatetarget.ts";
-import { checkForUnstableCheck } from "./effects/unstablecheck.ts";
-import { ChatMessagePF2e, CombatantPF2e, EffectPF2e, EncounterPF2e, ItemPF2e, MeasuredTemplateDocumentPF2e, TokenDocumentPF2e, TokenPF2e, UserPF2e } from "foundry-pf2e";
-import { runMatchingTemplateDeletionFunction, runMatchingTemplateFunctionAsCreator, runMatchingTemplateFunctionAsGm } from "./triggers.ts";
-import { ifActorHasSustainEffectCreateMessage, checkIfSpellInChatIsSustain, checkIfTemplatePlacedHasSustainEffect, handleSustainedEffectDeletion, createSpellNotSustainedChatMessage } from "./sustain.ts";
-import { applyAntagonizeIfValid, createChatMessageOnTurnStartIfTokenIsAntagonized, warnIfDeletedItemIsFrightenedWhileAntagonized } from "./actions/antagonize.ts";
+import {
+    targetTokensUnderTemplate,
+    deleteTemplateTargets,
+    setTemplateColorToBlack,
+    isLastTargetedTemplate
+} from "./templatetarget.ts";
+import { applyUnstableEffectOnFailure } from "./effects/unstablecheck.ts";
+import {
+    ChatMessagePF2e,
+    CombatantPF2e,
+    EffectPF2e,
+    EncounterPF2e,
+    ItemPF2e,
+    MeasuredTemplateDocumentPF2e,
+    TokenDocumentPF2e,
+    TokenPF2e,
+    UserPF2e
+} from "foundry-pf2e";
+import {
+    runMatchingTemplateDeletionFunction,
+    runMatchingTemplateFunctionAsCreator,
+    runMatchingTemplateFunctionAsGm
+} from "./triggers.ts";
+import {
+    postSustainMessagesForActor,
+    addSustainEffectToCaster,
+    associateTemplateWithSustainedEffect,
+    handleSustainedEffectDeletion,
+    createSpellNotSustainedChatMessage,
+    isAutomaticSustainSpell
+} from "./sustain.ts";
+import {
+    applyAntagonizeIfValid,
+    postAntagonizedTurnStartMessage,
+    warnIfDeletedItemIsFrightenedWhileAntagonized
+} from "./actions/antagonize.ts";
 import { handleFrightenedAtTurnEnd } from "./effects/frightened.ts";
-import { addButtonClickHandlersIfNeeded } from "./chatbuttonhelper.ts";
-import { postMessagesForWithinEffects, deleteWithinEffectsForTemplate, addEffectsToTokensInStartOfTurnTemplates, addOrRemoveWithinEffectIfNeeded } from "./startofturnspells.ts";
+import { addButtonClickHandlers } from "./chatbuttonhelper.ts";
+import {
+    postMessagesForWithinEffects,
+    deleteWithinEffectsForTemplate,
+    addEffectsToTokensInStartOfTurnTemplates,
+    addOrRemoveWithinEffectIfNeeded,
+    START_OF_TURN_SPELLS
+} from "./startofturnspells.ts";
 import ChatLog from "foundry-pf2e/foundry/client/applications/sidebar/tabs/chat.mjs";
 import { addDamageHelperButtonToChatUIv12, addDamageHelperButtonToChatUIv13 } from "./damagehelper.ts";
 import { getHtmlElement, MODULE_ID } from "./utils.ts";
@@ -20,19 +62,26 @@ import { handleHomebrewUnstableCheckResult, replaceUnstableCheckWithStrainCheck 
 import { runBoostEidolonAutomation } from "./spells/boosteidolon.ts";
 import { manifestEidolon } from "./actions/manifesteidolon.ts";
 import { registerSocket } from "./sockets.ts";
-import { oscillateEnergy } from "./conservationofenergy.ts";
+import { oscillateEnergy, isOscillateSpellCast } from "./conservationofenergy.ts";
 import { startImaginaryWeapon } from "./spells/imaginaryweapon.ts";
 import { addDancingBladeDamageButtons } from "./spells/dancingblade-anim.ts";
-import { deleteGhostlyCarrierEffectFromCaster, deleteGhostlyCarrierTokenOnEffectDeletion, moveGhostlyCarrierToCaster } from "./spells/ghostlycarrier.ts";
+import {
+    deleteGhostlyCarrierEffectFromCaster,
+    deleteGhostlyCarrierTokenOnEffectDeletion,
+    moveGhostlyCarrierToCaster
+} from "./spells/ghostlycarrier.ts";
 import { samiOliModuleAPI } from "./api.ts";
 import Module from "foundry-pf2e/foundry/client/packages/module.mjs";
 import {
-    checkForMirrorImageOnAttack,
+    resolveMirrorImageOnAttack,
     handleMirrorImageCreated,
     handleMirrorImageUpdated,
     handleMirrorImageDeleted,
     resolveMirrorImageRoll
 } from "./spells/mirrorimage.ts";
+import { hook } from "./hookrunner.ts";
+
+export { hook, HookRunner } from "./hookrunner.ts";
 
 Hooks.on("init", () => {
     registerSettings();
@@ -42,69 +91,102 @@ Hooks.on("init", () => {
     }
 });
 
-Hooks.once('socketlib.ready', () => {
+Hooks.once("socketlib.ready", () => {
     registerSocket();
 });
 
-Hooks.on('renderChatMessage', async (message: ChatMessagePF2e, html: JQuery<HTMLElement>) => {
-    hook(addAutoButtonIfNeeded, message, html)
+Hooks.on("renderChatMessage", async (message: ChatMessagePF2e, html: JQuery<HTMLElement>) => {
+    hook(addAutoButtonToMessage, message, html)
+        .if(() => canAddAutoButton(message))
         .run();
-    hook(editEnjoyTheShowSkillRollIfNeeded, message, html)
+    hook(editEnjoyTheShowSkillRoll, message, html)
+        .ifMessageOption("origin:item:slug:enjoy-the-show")
         .run();
-    hook(addButtonClickHandlersIfNeeded, message, html)
+    hook(addButtonClickHandlers, message, html)
+        .ifMessageHasFlag(MODULE_ID, "buttonSlug")
         .run();
     hook(replaceUnstableCheckWithStrainCheck, message, html)
         .ifEnabled(SETTINGS.UNSTABLE_CHECK_HOMEBREW)
+        .ifMessageOptionAny("origin:item:trait:unstable", "self:action:trait:unstable")
         .run();
     hook(addDancingBladeDamageButtons, message, html)
+        .ifMessageOption("samioli-module:dancing-blade-attack")
         .run();
 });
 
-Hooks.on("createMeasuredTemplate", async (template: MeasuredTemplateDocumentPF2e, _context, userId) => {
+Hooks.on("createMeasuredTemplate", async (
+    template: MeasuredTemplateDocumentPF2e,
+    _context,
+    userId
+) => {
     // Check for matching origin and run matching function if found (see triggers.ts)
-    let ranTemplateTrigger = hook(runMatchingTemplateFunctionAsGm, template).ifGM().run();
-    ranTemplateTrigger ||= hook(runMatchingTemplateFunctionAsCreator, template).ifUser(userId).run();
+    let ranTemplateTrigger = hook(runMatchingTemplateFunctionAsGm, template)
+        .ifGM()
+        .allowUnfilteredRun()
+        .run();
+    ranTemplateTrigger ||= hook(runMatchingTemplateFunctionAsCreator, template)
+        .ifUser(userId)
+        .allowUnfilteredRun()
+        .run();
 
     if (!ranTemplateTrigger) {
         // If no matching origin, target tokens if that feature is enabled
         hook(targetTokensUnderTemplate, template, userId)
             .ifEnabled(SETTINGS.TEMPLATE_TARGET)
+            .allowUnfilteredRun()
             .run();
     }
 
-    hook(checkIfTemplatePlacedHasSustainEffect, template)
+    hook(associateTemplateWithSustainedEffect, template)
         .ifEnabled(SETTINGS.AUTO_SUSTAIN_CHECK)
         .ifGM()
+        .if(() => template.actor?.items.some(
+            i => i.type === "effect" && (i.slug?.startsWith("sustaining-effect-") ?? false)
+        ) ?? false)
         .run();
 
     hook(addEffectsToTokensInStartOfTurnTemplates, template)
         .ifEnabled(SETTINGS.AUTO_START_OF_TURN_SPELL_CHECK)
         .ifGM()
+        .if(() => {
+            const slug = (template.flags.pf2e?.origin as { slug?: string } | undefined)?.slug;
+            return !!slug && START_OF_TURN_SPELLS.includes(slug);
+        })
         .run();
 });
 
-Hooks.on("preCreateMeasuredTemplate", (template: MeasuredTemplateDocumentPF2e, _data, _context, _userId) => {
+Hooks.on("preCreateMeasuredTemplate", (
+    template: MeasuredTemplateDocumentPF2e,
+    _data,
+    _context,
+    _userId
+) => {
     hook(setTemplateColorToBlack, template)
         .ifEnabled(SETTINGS.TEMPLATE_COLOUR_OVERRIDE)
+        .allowUnfilteredRun()
         .run();
 });
 
 Hooks.on("deleteMeasuredTemplate", (template: MeasuredTemplateDocumentPF2e) => {
     hook(runMatchingTemplateDeletionFunction, template)
         .ifGM()
+        .allowUnfilteredRun()
         .run();
     hook(deleteTemplateTargets, template)
         .ifEnabled(SETTINGS.TEMPLATE_TARGET)
+        .if(() => isLastTargetedTemplate(template.id))
         .run();
     hook(deleteWithinEffectsForTemplate, template)
         .ifEnabled(SETTINGS.AUTO_START_OF_TURN_SPELL_CHECK)
         .ifGM()
+        .if(() => !!template.getFlag("samioli-module", "startOfTurnEffectUuid")
+            || !!template.getFlag("samioli-module", "spellSource"))
         .run();
 });
 
 Hooks.on("createChatMessage", (message: ChatMessagePF2e, _rollmode, _userId) => {
     handleChatMessageWithRoll(message);
-    if (game.modules.get('dice-so-nice')?.active
+    if (game.modules.get("dice-so-nice")?.active
         && message.isRoll
         && message.rolls.some(roll => roll.dice.length > 0)) {
         // Includes a roll, message will be posted by DiceSoNice
@@ -113,69 +195,84 @@ Hooks.on("createChatMessage", (message: ChatMessagePF2e, _rollmode, _userId) => 
     handleChatMessagePostRoll(message);
 });
 
-Hooks.on('diceSoNiceRollComplete', (id: string) => {
+Hooks.on("diceSoNiceRollComplete", (id: string) => {
     const message = game.messages.get(id);
     if (message) {
         handleChatMessagePostRoll(message);
-    };
+    }
 });
 
-//pf2e.startTurn only runs for the GM
-Hooks.on('pf2e.startTurn', (combatant: CombatantPF2e, _encounter: EncounterPF2e, _id) => {
-    if (!combatant.actor) {
-        return;
-    }
-    hook(ifActorHasSustainEffectCreateMessage, combatant.actor)
+// pf2e.startTurn only runs for the GM
+Hooks.on("pf2e.startTurn", (combatant: CombatantPF2e, _encounter: EncounterPF2e, _id) => {
+    if (!combatant.actor) return;
+    hook(postSustainMessagesForActor, combatant.actor)
         .ifEnabled(SETTINGS.AUTO_SUSTAIN_CHECK)
+        .ifActorHasEffectWithSlugPrefix("sustaining-effect-")
         .run();
-    hook(createChatMessageOnTurnStartIfTokenIsAntagonized, combatant)
+    hook(postAntagonizedTurnStartMessage, combatant)
         .ifEnabled(SETTINGS.AUTO_FRIGHTENED_AND_ANTAGONIZE_CHECK)
+        .ifActorHasEffect("samioli-antagonized")
         .run();
     hook(postMessagesForWithinEffects, combatant)
         .ifEnabled(SETTINGS.AUTO_START_OF_TURN_SPELL_CHECK)
+        .ifActorHasEffectWithFlag("samioli-module", "startOfTurnSpellUuid")
         .run();
 });
 
-//pf2e.endTurn only runs for the GM
-Hooks.on('pf2e.endTurn', (combatant: CombatantPF2e, _encounter: EncounterPF2e, _id) => {
+// pf2e.endTurn only runs for the GM
+Hooks.on("pf2e.endTurn", (combatant: CombatantPF2e, _encounter: EncounterPF2e, _id) => {
     hook(handleFrightenedAtTurnEnd, combatant)
         .ifEnabled(SETTINGS.AUTO_FRIGHTENED_AND_ANTAGONIZE_CHECK)
+        .ifActorHasCondition("frightened")
         .run();
 });
 
-Hooks.on('preDeleteItem', async (item: ItemPF2e, _action, _id) => {
+Hooks.on("preDeleteItem", async (item: ItemPF2e, _action, _id) => {
     hook(createSpellNotSustainedChatMessage, item)
         .ifEnabled(SETTINGS.AUTO_SUSTAIN_CHECK)
+        .ifItemType("effect")
+        .ifItemSlugStartsWith("sustaining-effect-")
         .run();
     hook(handleSustainedEffectDeletion, item)
         .ifEnabled(SETTINGS.AUTO_SUSTAIN_CHECK)
+        .ifItemType("effect")
+        .ifItemSlugStartsWith("sustaining-effect-")
         .run();
     hook(warnIfDeletedItemIsFrightenedWhileAntagonized, item)
         .ifEnabled(SETTINGS.AUTO_FRIGHTENED_AND_ANTAGONIZE_CHECK)
+        .ifItemType("condition")
+        .ifItemSlug("frightened")
         .run();
     hook(deleteGhostlyCarrierTokenOnEffectDeletion, item)
+        .ifItemType("effect")
+        .ifItemSlug("samioli-ghostly-carrier")
         .run();
 });
 
-Hooks.on('preDeleteToken', async (token: TokenDocumentPF2e, _action, _id) => {
+Hooks.on("preDeleteToken", async (token: TokenDocumentPF2e, _action, _id) => {
     hook(deleteGhostlyCarrierEffectFromCaster, token)
         .ifGM()
+        .ifTokenHasFlag("samioli-module", "ghostlyCarrierEffectUUID")
         .run();
 });
 
-Hooks.on('moveToken', (token: TokenPF2e, movement, _action, _user: UserPF2e) => {
+Hooks.on("moveToken", (token: TokenPF2e, movement, _action, _user: UserPF2e) => {
     hook(addOrRemoveWithinEffectIfNeeded, token, movement.passed.cost)
         .ifGM()
         .ifEnabled(SETTINGS.AUTO_START_OF_TURN_SPELL_CHECK)
+        .ifSceneHasTemplateWithFlag("samioli-module", "isStartOfTurnSpell")
         .run();
     hook(moveGhostlyCarrierToCaster, token, movement.destination.x, movement.destination.y)
         .ifGM()
+        .ifActorHasEffect("samioli-ghostly-carrier")
         .run();
 });
 
 Hooks.on("createItem", (item: ItemPF2e, _context: unknown, userId: string) => {
     hook(handleMirrorImageCreated, item as EffectPF2e)
         .ifUser(userId)
+        .ifItemType("effect")
+        .ifItemSlug("spell-effect-mirror-image")
         .run();
 });
 
@@ -187,12 +284,16 @@ Hooks.on("updateItem", (
 ) => {
     hook(handleMirrorImageUpdated, item as EffectPF2e, changes)
         .ifUser(userId)
+        .ifItemType("effect")
+        .ifItemSlug("spell-effect-mirror-image")
         .run();
 });
 
 Hooks.on("deleteItem", (item: ItemPF2e, _context: unknown, userId: string) => {
     hook(handleMirrorImageDeleted, item as EffectPF2e)
         .ifUser(userId)
+        .ifItemType("effect")
+        .ifItemSlug("spell-effect-mirror-image")
         .run();
 });
 
@@ -202,6 +303,7 @@ Hooks.on("renderChatInput", (_app: ChatLog, cssMappings: Record<string, HTMLElem
     hook(addDamageHelperButtonToChatUIv13, cssMappings)
         .ifEnabled(SETTINGS.DAMAGE_HELPER_BUTTON)
         .ifGM()
+        .allowUnfilteredRun()
         .run();
 });
 
@@ -212,6 +314,7 @@ Hooks.on("renderChatLog", (_app: ChatLog, htmlOrJQuery: JQuery | HTMLElement,
         .ifEnabled(SETTINGS.DAMAGE_HELPER_BUTTON)
         .ifGM()
         .ifV12()
+        .allowUnfilteredRun()
         .run();
 });
 
@@ -220,6 +323,7 @@ function handleChatMessageWithRoll(message: ChatMessagePF2e) {
         case "attack-roll":
             hook(startImaginaryWeapon, message)
                 .ifMessagePosterAndActorOwner()
+                .ifMessageItemSlug("imaginary-weapon")
                 .run();
             break;
         case "damage-roll":
@@ -239,83 +343,114 @@ function handleChatMessageWithRoll(message: ChatMessagePF2e) {
 function handleChatMessagePostRoll(message: ChatMessagePF2e) {
     switch (getMessageType(message)) {
         case "attack-roll":
-            hook(checkForExtravagantParryOrElegantBuckler, message)
+            hook(applyPanacheForParryOrBuckler, message)
                 .ifEnabled(SETTINGS.AUTO_PANACHE)
                 .ifGM()
+                .ifMessageHasTarget()
+                .if(() => isParryOrBuckleEligible(message))
                 .run();
-            hook(checkForFinisherAttack, message)
+            hook(handleFinisherAttack, message)
                 .ifEnabled(SETTINGS.AUTO_PANACHE)
                 .ifGM()
+                .ifMessageOption("finisher")
                 .run();
-            hook(checkForBravado, message)
+            hook(applyPanacheForActor, message)
                 .ifEnabled(SETTINGS.AUTO_PANACHE)
                 .ifGM()
+                .ifMessageOption("item:trait:bravado")
+                .ifNotMessageOption("action:tumble-through")
+                .ifNotMessageOption("item:slug:enjoy-the-show")
+                .ifMessageOutcomeIn("failure", "success", "criticalSuccess")
                 .run();
-            hook(checkForMirrorImageOnAttack, message)
+            hook(resolveMirrorImageOnAttack, message)
                 .ifEnabled(SETTINGS.AUTO_MIRROR_IMAGE)
                 .ifGM()
+                .ifMessageHasTarget()
+                .ifTargetHasEffect("spell-effect-mirror-image")
+                .ifMessageOutcomeIn("failure", "success", "criticalSuccess")
                 .run();
             break;
         case "damage-roll":
-            hook(checkForFinisherDamage, message)
+            hook(clearPanacheForActor, message)
                 .ifEnabled(SETTINGS.AUTO_PANACHE)
                 .ifGM()
+                .ifMessageOption("finisher")
                 .run();
             hook(oscillateEnergy, message)
                 .ifEnabled(SETTINGS.AUTO_CONSERVATION_OF_ENERGY)
                 .ifGM()
+                .ifMessageOption("class:psychic")
+                .ifMessageOption("feature:the-oscillating-wave")
+                .if(() => isOscillateSpellCast(message))
                 .run();
             break;
         case "skill-check":
             hook(startTumbleThrough, message)
                 .ifMessagePoster()
+                .ifMessageOption("action:tumble-through")
                 .run();
             hook(startEnjoyTheShow, message)
                 .ifMessagePoster()
+                .ifMessageOption("item:slug:enjoy-the-show")
                 .run();
-            hook(checkForBravado, message)
+            hook(applyPanacheForActor, message)
                 .ifEnabled(SETTINGS.AUTO_PANACHE)
                 .ifGM()
+                .ifMessageOption("item:trait:bravado")
+                .ifNotMessageOption("action:tumble-through")
+                .ifNotMessageOption("item:slug:enjoy-the-show")
+                .ifMessageOutcomeIn("success", "failure", "criticalSuccess")
                 .run();
             hook(applyAntagonizeIfValid, message)
                 .ifEnabled(SETTINGS.AUTO_FRIGHTENED_AND_ANTAGONIZE_CHECK)
                 .ifGM()
+                .ifMessageOption("action:demoralize")
+                .ifMessageOutcomeIn("success", "criticalSuccess")
+                .ifActorHasFeat("antagonize")
                 .run();
             break;
         case "flat-check":
-            hook(checkForUnstableCheck, message)
+            hook(applyUnstableEffectOnFailure, message)
                 .ifEnabled(SETTINGS.AUTO_UNSTABLE_CHECK)
                 .ifGM()
+                .ifMessageOption("unstable-check")
+                .ifMessageOutcomeIn("failure", "criticalFailure")
                 .run();
             hook(handleHomebrewUnstableCheckResult, message)
                 .ifEnabled(SETTINGS.UNSTABLE_CHECK_HOMEBREW)
                 .ifGM()
+                .ifMessageOption("samioli-unstable-check")
                 .run();
             break;
         case "action":
             hook(startHuntPrey, message)
                 .ifEnabled(SETTINGS.AUTO_HUNT_PREY)
                 .ifMessagePosterAndActorOwner()
+                .ifMessageItemSlug("hunt-prey")
                 .run();
             hook(manifestEidolon, message)
                 .ifEnabled(SETTINGS.AUTO_MANIFEST_EIDOLON)
                 .ifMessagePosterAndActorOwner()
+                .ifMessageItemSlug("manifest-eidolon")
                 .run();
             break;
         case "spell":
         case "spell-cast":
-            hook(checkIfSpellInChatIsSustain, message)
+            hook(addSustainEffectToCaster, message)
                 .ifEnabled(SETTINGS.AUTO_SUSTAIN_CHECK)
                 .ifMessagePosterAndActorOwner()
+                .if(() => isAutomaticSustainSpell(message.item))
                 .run();
             hook(runBoostEidolonAutomation, message)
                 .ifEnabled(SETTINGS.AUTO_BOOST_EIDOLON)
                 .ifMessagePosterAndActorOwner()
+                .ifMessageItemSlug("boost-eidolon")
                 .run();
             break;
         case "mirror-image-roll":
             hook(resolveMirrorImageRoll, message)
                 .ifGM()
+                .allowUnfilteredRun()
                 .run();
             break;
     }
@@ -325,73 +460,4 @@ function getMessageType(message: ChatMessagePF2e) {
     return message.flags?.pf2e?.context?.type
         ?? message.flags?.pf2e?.origin?.type
         ?? message.flags?.[MODULE_ID]?.type;
-}
-
-export function hook<T extends unknown[]>(func: (...args: T) => void, ...args: T): HookRunner<T> {
-    return new HookRunner<T>(func, ...args);
-}
-
-export class HookRunner<T extends unknown[]> {
-    func: (...args: T) => boolean | void;
-    args: T;
-    shouldRun: boolean;
-
-    constructor(func: (...args: T) => void, ...args: T) {
-        this.func = func;
-        this.args = args;
-        this.shouldRun = true;
-    }
-
-    ifEnabled(...settings: SettingsKey[]): this {
-        for (const setting of settings) {
-            if (!getSetting(setting)) {
-                this.shouldRun = false;
-            }
-        }
-        return this;
-    }
-
-    ifGM(): this {
-        if (!game.user.isGM) {
-            this.shouldRun = false;
-        }
-        return this;
-    }
-
-    ifMessagePoster(): this {
-        const message = this.args[0] as ChatMessagePF2e;
-        if (game.user.id != message.author?.id) {
-            this.shouldRun = false;
-        }
-        return this;
-    }
-
-    ifMessagePosterAndActorOwner(): this {
-        const message = this.args[0] as ChatMessagePF2e;
-        if (game.user.id != message.author?.id || !message.actor?.isOwner) {
-            this.shouldRun = false;
-        }
-        return this;
-    }
-
-    ifUser(userId: string): this {
-        if (game.user.id != userId) {
-            this.shouldRun = false;
-        }
-        return this;
-    }
-
-    ifV12(): this {
-        if (!game.version.startsWith("12.")) {
-            this.shouldRun = false;
-        }
-        return this;
-    }
-
-    run() {
-        if (this.shouldRun) {
-            return this.func(...this.args);
-        }
-        return false;
-    }
 }

--- a/src/spells/boosteidolon.ts
+++ b/src/spells/boosteidolon.ts
@@ -6,8 +6,8 @@ type Tradition = "arcane" | "divine" | "occult" | "primal";
 type MagicSkill = "arcana" | "religion" | "occultism" | "nature";
 
 export async function runBoostEidolonAutomation(chatMessage: ChatMessagePF2e) {
-    const summonerActor = chatMessage.actor!;
-    if (!isCharacter(summonerActor)) return;
+    const summonerActor = chatMessage.actor;
+    if (!summonerActor || !isCharacter(summonerActor)) return;
     
     // Don't add button if summoner has no focus points remaining
     const hasFocusPoints = summonerActor.system.resources.focus.value > 0;

--- a/src/spells/boosteidolon.ts
+++ b/src/spells/boosteidolon.ts
@@ -6,12 +6,8 @@ type Tradition = "arcane" | "divine" | "occult" | "primal";
 type MagicSkill = "arcana" | "religion" | "occultism" | "nature";
 
 export async function runBoostEidolonAutomation(chatMessage: ChatMessagePF2e) {
-
-    // Check if the spell is Boost Eidolon
-    if (!chatMessage.flags?.pf2e?.origin?.rollOptions?.includes("origin:item:slug:boost-eidolon")) return;
-
-    const summonerActor = chatMessage.actor;
-    if (!summonerActor || !isCharacter(summonerActor)) return;
+    const summonerActor = chatMessage.actor!;
+    if (!isCharacter(summonerActor)) return;
     
     // Don't add button if summoner has no focus points remaining
     const hasFocusPoints = summonerActor.system.resources.focus.value > 0;

--- a/src/spells/dancingblade-anim.ts
+++ b/src/spells/dancingblade-anim.ts
@@ -1,5 +1,5 @@
 import type { ChatMessagePF2e, EffectPF2e, TokenPF2e, WeaponPF2e } from "foundry-pf2e";
-import { getTokensAtLocation, MODULE_ID } from "../utils.ts";
+import { getTokensAtLocation } from "../utils.ts";
 import type { Point } from "foundry-pf2e/foundry/common/_types.mjs";
 import { rollDancingBladeDamage } from "./dancingblade.ts";
 
@@ -414,12 +414,6 @@ async function startCrosshairsTargetSelection(token: TokenPF2e, range: number) {
  * Injects Damage and Critical buttons into the attack roll card footer.
  */
 export function addDancingBladeDamageButtons(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
-    const context = message.flags.pf2e.context;
-    if (context?.type !== "attack-roll") return;
-
-    const isDancingBlade = context.options?.includes(`${MODULE_ID}:dancing-blade-attack`);
-    if (!isDancingBlade) return;
-
     const damageButton = $('<button type="button" data-action="damage">Damage</button>');
     const criticalButton = $('<button type="button" data-action="critical">Critical</button>');
 

--- a/src/spells/imaginaryweapon.ts
+++ b/src/spells/imaginaryweapon.ts
@@ -6,7 +6,7 @@ export async function startImaginaryWeapon(message: ChatMessagePF2e) {
 
     // check if attack roll is Imaginary Weapon
     const contextOptions = message.flags.pf2e.context?.options;
-    if (!contextOptions?.includes("item:imaginary-weapon")) return;
+    if (!contextOptions) return;
 
     // determine what type of Imaginary Weapon has been cast
     const isAmped = contextOptions.includes("item:tag:amped");
@@ -20,8 +20,10 @@ export async function startImaginaryWeapon(message: ChatMessagePF2e) {
     }
 
     // get player who is doing the attack roll and capture targets
-    const user = message.author!;
-    const caster = message.token!;
+    const user = message.author;
+    if (!user) return;
+    const caster = message.token;
+    if (!caster) return;
     const targets = Array.from(user.targets)
     if (targets.length === 0) return;
 

--- a/src/spells/mirrorimage.ts
+++ b/src/spells/mirrorimage.ts
@@ -8,10 +8,7 @@ interface MirrorImageRollFlags {
     imagesCount: number;
 }
 
-export async function checkForMirrorImageOnAttack(chatMessage: ChatMessagePF2e): Promise<void> {
-    const context = chatMessage.flags.pf2e.context;
-    if (!context || context.type !== "attack-roll") return;
-
+export async function resolveMirrorImageOnAttack(chatMessage: ChatMessagePF2e): Promise<void> {
     const targetToken = chatMessage.target?.token?.object;
     const targetActor = targetToken?.actor;
     if (!targetActor || !targetToken) return;
@@ -24,8 +21,7 @@ export async function checkForMirrorImageOnAttack(chatMessage: ChatMessagePF2e):
     const imagesCount = effect.system.badge?.value;
     if (typeof imagesCount !== "number" || imagesCount <= 0) return;
 
-    const outcome = context.outcome;
-    if (outcome === "criticalFailure") return;
+    const outcome = chatMessage.flags.pf2e.context?.outcome;
 
     if (outcome === "failure") {
         await effect.decrease();

--- a/src/startofturnspells.ts
+++ b/src/startofturnspells.ts
@@ -2,7 +2,7 @@ import { ActorPF2e, CombatantPF2e, EffectSource, ItemPF2e, MeasuredTemplateDocum
 import { addOrUpdateEffectOnActor, delay, sendBasicChatMessage } from "./utils.ts";
 import { getTemplateTokens, isTokenInTemplateArea, replaceTargets } from "./templatetarget.ts";
 
-const START_OF_TURN_SPELLS = [
+export const START_OF_TURN_SPELLS = [
     'ash-cloud',
     'field-of-life',
     'sea-of-thought',

--- a/src/startofturnspells.ts
+++ b/src/startofturnspells.ts
@@ -263,3 +263,19 @@ function createWithinEffectSource(spell: SpellPF2e, template: MeasuredTemplateDo
     return effect as DeepPartial<EffectSource> as EffectSource;
 
 }
+
+/**
+ * Determines if the template originates from a known start-of-turn spell.
+ */
+export function isStartOfTurnSpellTemplate(template: MeasuredTemplateDocumentPF2e): boolean {
+    const slug = (template.flags.pf2e?.origin as { slug?: string } | undefined)?.slug;
+    return !!slug && START_OF_TURN_SPELLS.includes(slug);
+}
+
+/**
+ * Checks if the template has flags indicating it was placed for a start-of-turn spell.
+ */
+export function hasStartOfTurnFlags(template: MeasuredTemplateDocumentPF2e): boolean {
+    return !!template.getFlag("samioli-module", "startOfTurnEffectUuid")
+        || !!template.getFlag("samioli-module", "spellSource");
+}

--- a/src/sustain.ts
+++ b/src/sustain.ts
@@ -328,3 +328,12 @@ export async function handleSustainedEffectDeletion(item: ItemPF2e) {
 
     runMatchingSustainDeletionFunction(item);
 }
+
+/**
+ * Checks if the actor associated with the template has any active sustaining effects.
+ */
+export function hasSustainingEffect(template: MeasuredTemplateDocumentPF2e): boolean {
+    return template.actor?.items.some(
+        i => i.type === "effect" && (i.slug?.startsWith("sustaining-effect-") ?? false)
+    ) ?? false;
+}

--- a/src/sustain.ts
+++ b/src/sustain.ts
@@ -4,15 +4,16 @@ import { runMatchingSustainFunction, runMatchingSustainDeletionFunction, MANUAL_
 import { createChatMessageWithButton } from "./chatbuttonhelper.ts";
 import { getSocket, DELETE_SUMMON } from "./sockets.ts";
 
-export async function checkIfSpellInChatIsSustain(message: ChatMessagePF2e) {
-    const messageItem = message.item;
-    if (isSpellPF2e(messageItem)) {
-        if (hasSustainedDuration(messageItem)) {
-            if (MANUAL_SUSTAIN_SPELLS.has(getSpellSlug(messageItem))) return;
-            if (!message.actor) return;
-            await addSustainEffectToActor(message.actor, messageItem as unknown as SpellPF2e);
-        }
+export async function addSustainEffectToCaster(message: ChatMessagePF2e) {
+    if (message.actor && isSpellPF2e(message.item)) {
+        await addSustainEffectToActor(message.actor, message.item as unknown as SpellPF2e);
     }
+}
+
+export function isAutomaticSustainSpell(item: ItemPF2e | null): boolean {
+    if (!isSpellPF2e(item)) return false;
+    const spell = item as unknown as SpellPF2e;
+    return hasSustainedDuration(spell) && !MANUAL_SUSTAIN_SPELLS.has(getSpellSlug(spell));
 }
 
 /**
@@ -24,7 +25,7 @@ function getSpellSlug(spell: SpellPF2e): string {
     return (spell as unknown as { slug: string | null }).slug ?? "";
 }
 
-function hasSustainedDuration(spell: SpellPF2e): boolean {
+export function hasSustainedDuration(spell: SpellPF2e): boolean {
     // We cast through unknown to avoid "Type instantiation is excessively deep" errors 
     // caused by the complexity of the PF2e system's Spell types.
     const system = spell.system as unknown as { duration?: { sustained?: boolean } };
@@ -79,7 +80,7 @@ export async function addSustainEffectToActor(
     return addOrUpdateEffectOnActor(actor, effect as DeepPartial<EffectSource> as EffectSource);
 }
 
-export async function ifActorHasSustainEffectCreateMessage(actor: ActorPF2e) {
+export async function postSustainMessagesForActor(actor: ActorPF2e) {
     const sustainedEffects = getActorSustainedEffects(actor);
     if (!sustainedEffects) {
         return;
@@ -294,11 +295,13 @@ async function associateTemplateWithEffect(template: MeasuredTemplateDocumentPF2
     });
 }
 
-export async function checkIfTemplatePlacedHasSustainEffect(template: MeasuredTemplateDocumentPF2e) {
+export async function associateTemplateWithSustainedEffect(
+    template: MeasuredTemplateDocumentPF2e
+) {
+    const actor = template.actor;
+    if (!actor) return;
 
-    if (!template.actor) return;
-
-    const sustainedEffectsOnActor = getActorSustainedEffects(template.actor);
+    const sustainedEffectsOnActor = getActorSustainedEffects(actor);
     if (!sustainedEffectsOnActor) return;
 
     const spellSlugFromTemplate = template.item?.slug;
@@ -306,7 +309,7 @@ export async function checkIfTemplatePlacedHasSustainEffect(template: MeasuredTe
 
     const matchingEffect = sustainedEffectsOnActor.find(effect => {
         const spellId = effect.getFlag(MODULE_ID, "sustainedSpellId") as string;
-        const spell = template.actor!.items.get(spellId) as SpellPF2e;
+        const spell = actor.items.get(spellId) as SpellPF2e;
         return spell?.slug === spellSlugFromTemplate;
     });
 

--- a/src/templatetarget.ts
+++ b/src/templatetarget.ts
@@ -48,9 +48,13 @@ export async function targetTokensUnderTemplate(
     };
 }
 
-export function deleteTemplateTargets(template: MeasuredTemplateDocumentPF2e) {
+export function isLastTargetedTemplate(templateId: string): boolean {
+    return lastTemplateDetails?.templateId === templateId;
+}
+
+export function deleteTemplateTargets(_template: MeasuredTemplateDocumentPF2e) {
     const lastDetails = lastTemplateDetails;
-    if (!lastDetails || lastDetails?.templateId != template.id) {
+    if (!lastDetails) {
         return;
     }
 

--- a/src/unstablehomebrew.ts
+++ b/src/unstablehomebrew.ts
@@ -3,28 +3,25 @@ import { ImageFilePath } from "foundry-pf2e/foundry/common/constants.mjs";
 import { addOrUpdateEffectOnActor, performFlatCheck } from "./utils.ts";
 import { replaceTargets } from "./templatetarget.ts";
 
-export function replaceUnstableCheckWithStrainCheck(chatMessage: ChatMessagePF2e, html: JQuery<HTMLElement>) {
+export function replaceUnstableCheckWithStrainCheck(
+    chatMessage: ChatMessagePF2e,
+    html: JQuery<HTMLElement>
+) {
+    const flatCheckLink = html.find('a.inline-check[data-pf2-dc="15"][data-pf2-check="flat"]');
+    if (!flatCheckLink.length) return;
+    const strainDC = getStrainDC(chatMessage.actor!);
 
-    const rollOptions = chatMessage.flags.pf2e?.context?.options 
-        ?? chatMessage.flags.pf2e?.origin?.rollOptions;
-    if (!rollOptions) return;
+    const button = $(
+        `<a class="inline-check unstable-action-button">` +
+        `<i class="fa-solid fa-screwdriver-wrench"></i> ` +
+        `Strain Check DC ${strainDC}</a>`
+    );
 
-    if (rollOptions.includes("origin:item:trait:unstable") 
-        || rollOptions.includes("self:action:trait:unstable")) {
+    button.on("click", async () => {
+        rollAgainstStrainDC(chatMessage.actor!);
+    });
 
-        const flatCheckLink = html.find('a.inline-check[data-pf2-dc="15"][data-pf2-check="flat"]');
-
-        if (!flatCheckLink.length) return;
-        const strainDC = getStrainDC(chatMessage.actor!);
-
-        const button = $(`<a class="inline-check unstable-action-button"><i class="fa-solid fa-screwdriver-wrench"></i> Strain Check DC ${strainDC}</a>`);
-
-        button.on("click", async () => {
-            rollAgainstStrainDC(chatMessage.actor!);
-        });
-
-        flatCheckLink.replaceWith(button);
-    }
+    flatCheckLink.replaceWith(button);
 }
 
 function getStrainDC(actor: ActorPF2e) : number {
@@ -41,9 +38,6 @@ async function rollAgainstStrainDC(actor: ActorPF2e) {
 }
 
 export function handleHomebrewUnstableCheckResult(chatMessage: ChatMessagePF2e) {
-
-    const rollOptions = chatMessage.flags.pf2e?.context?.options;
-    if (!rollOptions || !rollOptions.includes("samioli-unstable-check")) return;
     
     const actor = chatMessage.actor!;
     const outcome = chatMessage.flags.pf2e?.context?.outcome;

--- a/src/unstablehomebrew.ts
+++ b/src/unstablehomebrew.ts
@@ -9,7 +9,9 @@ export function replaceUnstableCheckWithStrainCheck(
 ) {
     const flatCheckLink = html.find('a.inline-check[data-pf2-dc="15"][data-pf2-check="flat"]');
     if (!flatCheckLink.length) return;
-    const strainDC = getStrainDC(chatMessage.actor!);
+    const actor = chatMessage.actor;
+    if (!actor) return;
+    const strainDC = getStrainDC(actor);
 
     const button = $(
         `<a class="inline-check unstable-action-button">` +
@@ -18,7 +20,7 @@ export function replaceUnstableCheckWithStrainCheck(
     );
 
     button.on("click", async () => {
-        rollAgainstStrainDC(chatMessage.actor!);
+        rollAgainstStrainDC(actor);
     });
 
     flatCheckLink.replaceWith(button);
@@ -38,8 +40,8 @@ async function rollAgainstStrainDC(actor: ActorPF2e) {
 }
 
 export function handleHomebrewUnstableCheckResult(chatMessage: ChatMessagePF2e) {
-    
-    const actor = chatMessage.actor!;
+    const actor = chatMessage.actor;
+    if (!actor) return;
     const outcome = chatMessage.flags.pf2e?.context?.outcome;
 
     if (outcome === "failure" || outcome === "criticalFailure" ) {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -341,7 +341,7 @@ describe('Baseline Hook Handlers', () => {
     it('checkIfSpellInChatIsSustain: should add sustain effect if spell has sustained duration', async () => {
       const mockActor = {
         items: Object.assign([], { find: vi.fn().mockReturnValue(undefined) }),
-        createEmbeddedDocuments: vi.fn()
+        createEmbeddedDocuments: vi.fn().mockResolvedValue([ { name: 'Sustaining: Bless' } ])
       } as unknown as ActorPF2e;
 
       const mockSpell = {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -198,6 +198,27 @@ describe('Baseline Hook Handlers', () => {
       expect(isParryOrBuckleEligible(mockMessage)).toBe(true);
     });
 
+    it('isParryOrBuckleEligible: should return true if extravagant-parry option + failure', () => {
+      const mockTargetActor = {
+        items: Object.assign([], { contents: [] })
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        target: { actor: mockTargetActor },
+        flags: {
+          pf2e: {
+            context: {
+              type: 'attack-roll',
+              options: ['target:effect:extravagant-parry'],
+              outcome: 'failure'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      expect(isParryOrBuckleEligible(mockMessage)).toBe(true);
+    });
+
     it('applyPanacheForParryOrBuckler: should apply failure panache to target actor', async () => {
       const mockPanacheEffect = {
         id: 'effect-id',

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1,0 +1,408 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import {
+  checkForBravado,
+  checkIfProvidesPanache,
+  checkForFinisherAttack,
+  checkForFinisherDamage,
+  checkForExtravagantParryOrElegantBuckler
+} from '../src/effects/panache.ts';
+import { checkForMirrorImageOnAttack } from '../src/spells/mirrorimage.ts';
+import { checkForUnstableCheck } from '../src/effects/unstablecheck.ts';
+import {
+  checkIfSpellInChatIsSustain,
+  checkIfTemplatePlacedHasSustainEffect
+} from '../src/sustain.ts';
+import { ActorPF2e, ChatMessagePF2e, ItemPF2e, MeasuredTemplateDocumentPF2e } from 'foundry-pf2e';
+
+// Mock chatbuttonhelper to avoid real chat message creation
+vi.mock('../src/chatbuttonhelper.ts', () => ({
+  createChatMessageWithButton: vi.fn().mockResolvedValue({})
+}));
+
+// Setup global CONFIG mock
+const mockDamageRollToMessage = vi.fn().mockResolvedValue({});
+class MockDamageRoll {
+  constructor(public expr: string) {}
+  toMessage = mockDamageRollToMessage;
+}
+(globalThis as unknown as { CONFIG: unknown }).CONFIG = {
+  Dice: {
+    rolls: [MockDamageRoll]
+  }
+};
+
+// Mock game.packs
+const mockGetDocument = vi.fn().mockResolvedValue({
+  toObject: () => ({ name: 'Mock Effect', type: 'effect', system: { slug: 'effect-panache' } })
+});
+const mockPack = { getDocument: mockGetDocument };
+
+describe('Baseline Hook Handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set up standard game globals
+    (globalThis as unknown as { game: unknown }).game = {
+      user: {
+        isGM: true,
+        id: 'gm-user-id',
+      },
+      users: [
+        { isGM: true, id: 'gm-user-id' }
+      ],
+      packs: {
+        get: vi.fn().mockReturnValue(mockPack),
+      },
+      actors: {
+        get: vi.fn(),
+      },
+      version: '13.336',
+    };
+
+    // Set up standard ChatMessage global mock
+    (globalThis as unknown as { ChatMessage: unknown }).ChatMessage = {
+      create: vi.fn().mockResolvedValue({}),
+      getSpeaker: vi.fn().mockReturnValue({}),
+    };
+
+    // Set up standard ui notifications mock
+    (globalThis as unknown as { ui: unknown }).ui = {
+      notifications: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+      }
+    };
+  });
+
+  describe('Panache Handlers', () => {
+    it('checkForBravado: should not apply panache if trait bravado is missing', async () => {
+      const mockActor = {
+        items: Object.assign([], { contents: [] }),
+        createEmbeddedDocuments: vi.fn()
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        actor: mockActor,
+        flags: {
+          pf2e: {
+            context: {
+              options: ['some-other-option'],
+              outcome: 'success'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkForBravado(mockMessage);
+      expect(mockActor.createEmbeddedDocuments).not.toHaveBeenCalled();
+    });
+
+    it('checkForBravado: should apply panache if bravado option is present and outcome is success', async () => {
+      const mockActor = {
+        items: Object.assign([], { contents: [], find: vi.fn() }),
+        createEmbeddedDocuments: vi.fn()
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        actor: mockActor,
+        flags: {
+          pf2e: {
+            context: {
+              options: ['item:trait:bravado'],
+              outcome: 'success'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkForBravado(mockMessage);
+      expect(mockActor.createEmbeddedDocuments).toHaveBeenCalled();
+    });
+
+    it('checkIfProvidesPanache: should apply failure panache if outcome is failure', async () => {
+      const mockPanacheEffect = {
+        id: 'effect-id',
+        name: 'Effect: Panache (1 round)',
+        type: 'effect',
+        system: { slug: 'effect-panache' }
+      };
+
+      const mockActor = {
+        items: Object.assign([], {
+          contents: [],
+          find: () => mockPanacheEffect
+        }),
+        createEmbeddedDocuments: vi.fn(),
+        updateEmbeddedDocuments: vi.fn()
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        actor: mockActor,
+        flags: {
+          pf2e: {
+            context: {
+              options: ['item:trait:bravado'],
+              outcome: 'failure'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkIfProvidesPanache(mockMessage);
+      expect(mockActor.createEmbeddedDocuments).toHaveBeenCalled();
+      expect(mockActor.updateEmbeddedDocuments).toHaveBeenCalledWith('Item', [
+        expect.objectContaining({ _id: 'effect-id', name: 'Effect: Panache (1 round)' })
+      ]);
+    });
+
+    it('checkForFinisherAttack: should prompt removing panache on failure', async () => {
+      const mockActor = {} as unknown as ActorPF2e;
+      const mockMessage = {
+        actor: mockActor,
+        flags: {
+          pf2e: {
+            context: {
+              options: ['finisher'],
+              outcome: 'failure'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      const { createChatMessageWithButton } = await import('../src/chatbuttonhelper.ts');
+      await checkForFinisherAttack(mockMessage);
+      expect(createChatMessageWithButton).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: 'remove-panache', actor: mockActor })
+      );
+    });
+
+    it('checkForFinisherDamage: should clear panache when damage is rolled', async () => {
+      const deleteMock = vi.fn();
+      const mockPanache = {
+        type: 'effect',
+        system: { slug: 'effect-panache' },
+        delete: deleteMock
+      };
+      const itemsList = [mockPanache];
+      const mockActor = {
+        items: Object.assign(itemsList, { contents: itemsList })
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        actor: mockActor,
+        flags: {
+          pf2e: {
+            context: {
+              options: ['finisher']
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkForFinisherDamage(mockMessage);
+      expect(deleteMock).toHaveBeenCalled();
+    });
+
+    it('checkForExtravagantParryOrElegantBuckler: should apply panache to target on shield raised + crit failure if they have feat', async () => {
+      const mockPanacheEffect = {
+        id: 'effect-id',
+        type: 'effect',
+        system: { slug: 'effect-panache' }
+      };
+
+      const mockTargetActor = {
+        items: Object.assign([mockPanacheEffect], { contents: [
+          { type: 'feat', system: { category: 'class', slug: 'elegant-buckler' } }
+        ], find: () => mockPanacheEffect }),
+        createEmbeddedDocuments: vi.fn(),
+        updateEmbeddedDocuments: vi.fn()
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        target: {
+          actor: mockTargetActor
+        },
+        flags: {
+          pf2e: {
+            context: {
+              type: 'attack-roll',
+              options: ['target:effect:raise-a-shield'],
+              outcome: 'criticalFailure',
+              target: { actor: 'Actor.1234' }
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkForExtravagantParryOrElegantBuckler(mockMessage);
+      expect(mockTargetActor.createEmbeddedDocuments).toHaveBeenCalled();
+    });
+  });
+
+  describe('Mirror Image Handlers', () => {
+    it('checkForMirrorImageOnAttack: should decrease image count on failure', async () => {
+      const decreaseMock = vi.fn();
+      const mockEffect = {
+        slug: 'spell-effect-mirror-image',
+        system: { badge: { value: 3 } },
+        decrease: decreaseMock
+      };
+      const mockTargetActor = {
+        itemTypes: {
+          effect: [mockEffect]
+        }
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        target: {
+          actor: mockTargetActor,
+          token: { object: { actor: mockTargetActor, document: {} } }
+        },
+        flags: {
+          pf2e: {
+            context: {
+              type: 'attack-roll',
+              outcome: 'failure'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkForMirrorImageOnAttack(mockMessage);
+      expect(decreaseMock).toHaveBeenCalled();
+      expect(ChatMessage.create).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('destroys a <strong>Mirror Image</strong>') })
+      );
+    });
+
+    it('checkForMirrorImageOnAttack: should prompt image roll on success', async () => {
+      const mockEffect = {
+        slug: 'spell-effect-mirror-image',
+        system: { badge: { value: 3 } }
+      };
+      const mockTargetActor = {
+        itemTypes: {
+          effect: [mockEffect]
+        }
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        target: {
+          actor: mockTargetActor,
+          token: { object: { actor: mockTargetActor, document: {} } }
+        },
+        flags: {
+          pf2e: {
+            context: {
+              type: 'attack-roll',
+              outcome: 'success'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      const { createChatMessageWithButton } = await import('../src/chatbuttonhelper.ts');
+      await checkForMirrorImageOnAttack(mockMessage);
+      expect(createChatMessageWithButton).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: 'roll-mirror-image', actor: mockTargetActor })
+      );
+    });
+  });
+
+  describe('Unstable Check Handlers', () => {
+    it('checkForUnstableCheck: should apply unstable effect on flat-check failure', async () => {
+      const mockActor = {
+        createEmbeddedDocuments: vi.fn()
+      } as unknown as ActorPF2e;
+
+      vi.spyOn(game.actors, 'get').mockReturnValue(mockActor);
+
+      const mockMessage = {
+        flags: {
+          pf2e: {
+            context: {
+              type: 'flat-check',
+              options: ['unstable-check'],
+              outcome: 'failure',
+              actor: 'actor-id'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkForUnstableCheck(mockMessage);
+      expect(game.actors.get).toHaveBeenCalledWith('actor-id');
+      expect(mockActor.createEmbeddedDocuments).toHaveBeenCalled();
+    });
+  });
+
+  describe('Sustain Spell Handlers', () => {
+    it('checkIfSpellInChatIsSustain: should add sustain effect if spell has sustained duration', async () => {
+      const mockActor = {
+        items: Object.assign([], { find: vi.fn().mockReturnValue(undefined) }),
+        createEmbeddedDocuments: vi.fn()
+      } as unknown as ActorPF2e;
+
+      const mockSpell = {
+        type: 'spell',
+        name: 'Bless',
+        img: 'bless.webp',
+        system: {
+          description: { value: 'Bless description' },
+          duration: { sustained: true },
+          level: { value: 1 }
+        }
+      } as unknown as ItemPF2e;
+
+      const mockMessage = {
+        item: mockSpell,
+        actor: mockActor,
+        flags: {
+          pf2e: {}
+        }
+      } as unknown as ChatMessagePF2e;
+
+      await checkIfSpellInChatIsSustain(mockMessage);
+      expect(mockActor.createEmbeddedDocuments).toHaveBeenCalledWith(
+        'Item',
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'Sustaining: Bless',
+            type: 'effect'
+          })
+        ])
+      );
+    });
+
+    it('checkIfTemplatePlacedHasSustainEffect: should associate template with effect if slugs match', async () => {
+      const mockEffect = {
+        type: 'effect',
+        slug: 'sustaining-effect-bless',
+        system: { slug: 'sustaining-effect-bless' },
+        getFlag: vi.fn().mockReturnValue('spell-id'),
+        update: vi.fn()
+      };
+
+      const mockActor = {
+        items: Object.assign([mockEffect], {
+          contents: [mockEffect],
+          get: vi.fn().mockReturnValue({ slug: 'bless' }),
+          filter: Array.prototype.filter
+        })
+      } as unknown as ActorPF2e;
+
+      const mockTemplate = {
+        id: 'template-id',
+        actor: mockActor,
+        item: { slug: 'bless' },
+        update: vi.fn()
+      } as unknown as MeasuredTemplateDocumentPF2e;
+
+      await checkIfTemplatePlacedHasSustainEffect(mockTemplate);
+      expect(mockEffect.update).toHaveBeenCalledWith({
+        'flags.samioli-module.sustainedTemplateId': 'template-id'
+      });
+    });
+  });
+});

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -4,7 +4,7 @@ import {
   handleFinisherAttack,
   clearPanacheForActor,
   applyPanacheForParryOrBuckler,
-  isParryOrBuckleEligible
+  isPanacheGeneratingParryOrBuckler
 } from '../src/effects/panache.ts';
 import { resolveMirrorImageOnAttack } from '../src/spells/mirrorimage.ts';
 import { applyUnstableEffectOnFailure } from '../src/effects/unstablecheck.ts';
@@ -195,7 +195,7 @@ describe('Baseline Hook Handlers', () => {
         }
       } as unknown as ChatMessagePF2e;
 
-      expect(isParryOrBuckleEligible(mockMessage)).toBe(true);
+      expect(isPanacheGeneratingParryOrBuckler(mockMessage)).toBe(true);
     });
 
     it('isParryOrBuckleEligible: should return true if extravagant-parry option + failure', () => {
@@ -216,7 +216,7 @@ describe('Baseline Hook Handlers', () => {
         }
       } as unknown as ChatMessagePF2e;
 
-      expect(isParryOrBuckleEligible(mockMessage)).toBe(true);
+      expect(isPanacheGeneratingParryOrBuckler(mockMessage)).toBe(true);
     });
 
     it('applyPanacheForParryOrBuckler: should apply failure panache to target actor', async () => {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1,16 +1,16 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import {
-  checkForBravado,
-  checkIfProvidesPanache,
-  checkForFinisherAttack,
-  checkForFinisherDamage,
-  checkForExtravagantParryOrElegantBuckler
+  applyPanacheForActor,
+  handleFinisherAttack,
+  clearPanacheForActor,
+  applyPanacheForParryOrBuckler,
+  isParryOrBuckleEligible
 } from '../src/effects/panache.ts';
-import { checkForMirrorImageOnAttack } from '../src/spells/mirrorimage.ts';
-import { checkForUnstableCheck } from '../src/effects/unstablecheck.ts';
+import { resolveMirrorImageOnAttack } from '../src/spells/mirrorimage.ts';
+import { applyUnstableEffectOnFailure } from '../src/effects/unstablecheck.ts';
 import {
-  checkIfSpellInChatIsSustain,
-  checkIfTemplatePlacedHasSustainEffect
+  addSustainEffectToCaster,
+  associateTemplateWithSustainedEffect
 } from '../src/sustain.ts';
 import { ActorPF2e, ChatMessagePF2e, ItemPF2e, MeasuredTemplateDocumentPF2e } from 'foundry-pf2e';
 
@@ -76,29 +76,7 @@ describe('Baseline Hook Handlers', () => {
   });
 
   describe('Panache Handlers', () => {
-    it('checkForBravado: should not apply panache if trait bravado is missing', async () => {
-      const mockActor = {
-        items: Object.assign([], { contents: [] }),
-        createEmbeddedDocuments: vi.fn()
-      } as unknown as ActorPF2e;
-
-      const mockMessage = {
-        actor: mockActor,
-        flags: {
-          pf2e: {
-            context: {
-              options: ['some-other-option'],
-              outcome: 'success'
-            }
-          }
-        }
-      } as unknown as ChatMessagePF2e;
-
-      await checkForBravado(mockMessage);
-      expect(mockActor.createEmbeddedDocuments).not.toHaveBeenCalled();
-    });
-
-    it('checkForBravado: should apply panache if bravado option is present and outcome is success', async () => {
+    it('applyPanacheForActor: should apply panache if outcome is success', async () => {
       const mockActor = {
         items: Object.assign([], { contents: [], find: vi.fn() }),
         createEmbeddedDocuments: vi.fn()
@@ -109,18 +87,17 @@ describe('Baseline Hook Handlers', () => {
         flags: {
           pf2e: {
             context: {
-              options: ['item:trait:bravado'],
               outcome: 'success'
             }
           }
         }
       } as unknown as ChatMessagePF2e;
 
-      await checkForBravado(mockMessage);
+      await applyPanacheForActor(mockMessage);
       expect(mockActor.createEmbeddedDocuments).toHaveBeenCalled();
     });
 
-    it('checkIfProvidesPanache: should apply failure panache if outcome is failure', async () => {
+    it('applyPanacheForActor: should apply failure panache if outcome is failure', async () => {
       const mockPanacheEffect = {
         id: 'effect-id',
         name: 'Effect: Panache (1 round)',
@@ -142,28 +119,26 @@ describe('Baseline Hook Handlers', () => {
         flags: {
           pf2e: {
             context: {
-              options: ['item:trait:bravado'],
               outcome: 'failure'
             }
           }
         }
       } as unknown as ChatMessagePF2e;
 
-      await checkIfProvidesPanache(mockMessage);
+      await applyPanacheForActor(mockMessage);
       expect(mockActor.createEmbeddedDocuments).toHaveBeenCalled();
       expect(mockActor.updateEmbeddedDocuments).toHaveBeenCalledWith('Item', [
         expect.objectContaining({ _id: 'effect-id', name: 'Effect: Panache (1 round)' })
       ]);
     });
 
-    it('checkForFinisherAttack: should prompt removing panache on failure', async () => {
+    it('handleFinisherAttack: should prompt removing panache on failure', async () => {
       const mockActor = {} as unknown as ActorPF2e;
       const mockMessage = {
         actor: mockActor,
         flags: {
           pf2e: {
             context: {
-              options: ['finisher'],
               outcome: 'failure'
             }
           }
@@ -171,13 +146,13 @@ describe('Baseline Hook Handlers', () => {
       } as unknown as ChatMessagePF2e;
 
       const { createChatMessageWithButton } = await import('../src/chatbuttonhelper.ts');
-      await checkForFinisherAttack(mockMessage);
+      await handleFinisherAttack(mockMessage);
       expect(createChatMessageWithButton).toHaveBeenCalledWith(
         expect.objectContaining({ slug: 'remove-panache', actor: mockActor })
       );
     });
 
-    it('checkForFinisherDamage: should clear panache when damage is rolled', async () => {
+    it('clearPanacheForActor: should clear panache when damage is rolled', async () => {
       const deleteMock = vi.fn();
       const mockPanache = {
         type: 'effect',
@@ -193,18 +168,37 @@ describe('Baseline Hook Handlers', () => {
         actor: mockActor,
         flags: {
           pf2e: {
+            context: {}
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      clearPanacheForActor(mockMessage);
+      expect(deleteMock).toHaveBeenCalled();
+    });
+
+    it('isParryOrBuckleEligible: should return true if dueling-parry option + failure', () => {
+      const mockTargetActor = {
+        items: Object.assign([], { contents: [] })
+      } as unknown as ActorPF2e;
+
+      const mockMessage = {
+        target: { actor: mockTargetActor },
+        flags: {
+          pf2e: {
             context: {
-              options: ['finisher']
+              type: 'attack-roll',
+              options: ['target:effect:dueling-parry'],
+              outcome: 'failure'
             }
           }
         }
       } as unknown as ChatMessagePF2e;
 
-      await checkForFinisherDamage(mockMessage);
-      expect(deleteMock).toHaveBeenCalled();
+      expect(isParryOrBuckleEligible(mockMessage)).toBe(true);
     });
 
-    it('checkForExtravagantParryOrElegantBuckler: should apply panache to target on shield raised + crit failure if they have feat', async () => {
+    it('applyPanacheForParryOrBuckler: should apply failure panache to target actor', async () => {
       const mockPanacheEffect = {
         id: 'effect-id',
         type: 'effect',
@@ -212,9 +206,10 @@ describe('Baseline Hook Handlers', () => {
       };
 
       const mockTargetActor = {
-        items: Object.assign([mockPanacheEffect], { contents: [
-          { type: 'feat', system: { category: 'class', slug: 'elegant-buckler' } }
-        ], find: () => mockPanacheEffect }),
+        items: Object.assign([mockPanacheEffect], {
+          contents: [],
+          find: () => mockPanacheEffect
+        }),
         createEmbeddedDocuments: vi.fn(),
         updateEmbeddedDocuments: vi.fn()
       } as unknown as ActorPF2e;
@@ -226,22 +221,19 @@ describe('Baseline Hook Handlers', () => {
         flags: {
           pf2e: {
             context: {
-              type: 'attack-roll',
-              options: ['target:effect:raise-a-shield'],
-              outcome: 'criticalFailure',
-              target: { actor: 'Actor.1234' }
+              outcome: 'failure'
             }
           }
         }
       } as unknown as ChatMessagePF2e;
 
-      await checkForExtravagantParryOrElegantBuckler(mockMessage);
+      await applyPanacheForParryOrBuckler(mockMessage);
       expect(mockTargetActor.createEmbeddedDocuments).toHaveBeenCalled();
     });
   });
 
   describe('Mirror Image Handlers', () => {
-    it('checkForMirrorImageOnAttack: should decrease image count on failure', async () => {
+    it('resolveMirrorImageOnAttack: should decrease image count on failure', async () => {
       const decreaseMock = vi.fn();
       const mockEffect = {
         slug: 'spell-effect-mirror-image',
@@ -262,21 +254,22 @@ describe('Baseline Hook Handlers', () => {
         flags: {
           pf2e: {
             context: {
-              type: 'attack-roll',
               outcome: 'failure'
             }
           }
         }
       } as unknown as ChatMessagePF2e;
 
-      await checkForMirrorImageOnAttack(mockMessage);
+      await resolveMirrorImageOnAttack(mockMessage);
       expect(decreaseMock).toHaveBeenCalled();
       expect(ChatMessage.create).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('destroys a <strong>Mirror Image</strong>') })
+        expect.objectContaining({
+          content: expect.stringContaining('destroys a <strong>Mirror Image</strong>')
+        })
       );
     });
 
-    it('checkForMirrorImageOnAttack: should prompt image roll on success', async () => {
+    it('resolveMirrorImageOnAttack: should prompt image roll on success', async () => {
       const mockEffect = {
         slug: 'spell-effect-mirror-image',
         system: { badge: { value: 3 } }
@@ -295,7 +288,6 @@ describe('Baseline Hook Handlers', () => {
         flags: {
           pf2e: {
             context: {
-              type: 'attack-roll',
               outcome: 'success'
             }
           }
@@ -303,7 +295,7 @@ describe('Baseline Hook Handlers', () => {
       } as unknown as ChatMessagePF2e;
 
       const { createChatMessageWithButton } = await import('../src/chatbuttonhelper.ts');
-      await checkForMirrorImageOnAttack(mockMessage);
+      await resolveMirrorImageOnAttack(mockMessage);
       expect(createChatMessageWithButton).toHaveBeenCalledWith(
         expect.objectContaining({ slug: 'roll-mirror-image', actor: mockTargetActor })
       );
@@ -311,7 +303,7 @@ describe('Baseline Hook Handlers', () => {
   });
 
   describe('Unstable Check Handlers', () => {
-    it('checkForUnstableCheck: should apply unstable effect on flat-check failure', async () => {
+    it('applyUnstableEffectOnFailure: should apply unstable effect on failure', async () => {
       const mockActor = {
         createEmbeddedDocuments: vi.fn()
       } as unknown as ActorPF2e;
@@ -322,23 +314,20 @@ describe('Baseline Hook Handlers', () => {
         flags: {
           pf2e: {
             context: {
-              type: 'flat-check',
-              options: ['unstable-check'],
-              outcome: 'failure',
               actor: 'actor-id'
             }
           }
         }
       } as unknown as ChatMessagePF2e;
 
-      await checkForUnstableCheck(mockMessage);
+      await applyUnstableEffectOnFailure(mockMessage);
       expect(game.actors.get).toHaveBeenCalledWith('actor-id');
       expect(mockActor.createEmbeddedDocuments).toHaveBeenCalled();
     });
   });
 
   describe('Sustain Spell Handlers', () => {
-    it('checkIfSpellInChatIsSustain: should add sustain effect if spell has sustained duration', async () => {
+    it('addSustainEffectToCaster: should add sustain effect if spell has sustained duration', async () => {
       const mockActor = {
         items: Object.assign([], { find: vi.fn().mockReturnValue(undefined) }),
         createEmbeddedDocuments: vi.fn().mockResolvedValue([ { name: 'Sustaining: Bless' } ])
@@ -363,7 +352,7 @@ describe('Baseline Hook Handlers', () => {
         }
       } as unknown as ChatMessagePF2e;
 
-      await checkIfSpellInChatIsSustain(mockMessage);
+      await addSustainEffectToCaster(mockMessage);
       expect(mockActor.createEmbeddedDocuments).toHaveBeenCalledWith(
         'Item',
         expect.arrayContaining([
@@ -375,7 +364,7 @@ describe('Baseline Hook Handlers', () => {
       );
     });
 
-    it('checkIfTemplatePlacedHasSustainEffect: should associate template with effect if slugs match', async () => {
+    it('associateTemplateWithSustainedEffect: should associate template with effect', async () => {
       const mockEffect = {
         type: 'effect',
         slug: 'sustaining-effect-bless',
@@ -399,7 +388,7 @@ describe('Baseline Hook Handlers', () => {
         update: vi.fn()
       } as unknown as MeasuredTemplateDocumentPF2e;
 
-      await checkIfTemplatePlacedHasSustainEffect(mockTemplate);
+      await associateTemplateWithSustainedEffect(mockTemplate);
       expect(mockEffect.update).toHaveBeenCalledWith({
         'flags.samioli-module.sustainedTemplateId': 'template-id'
       });

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { hook } from '../src/hooks.ts';
+import { SETTINGS } from '../src/settings.ts';
+import { ChatMessagePF2e, GamePF2e } from 'foundry-pf2e';
+
+// Mock getSetting
+const mockSettings = new Map<string, boolean>();
+vi.mock('../src/settings.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/settings.ts')>();
+  return {
+    ...original,
+    getSetting: (key: string) => mockSettings.get(key) ?? false,
+  };
+});
+
+describe('HookRunner & hook helper', () => {
+  beforeEach(() => {
+    mockSettings.clear();
+    // Setup basic global game mock structure
+    (globalThis as unknown as { game: GamePF2e }).game = {
+      user: {
+        isGM: false,
+        id: 'current-user-id',
+      },
+      version: '13.336',
+    } as unknown as GamePF2e;
+  });
+
+  it('should run callback with correct args if no conditions specified', () => {
+    const callback = vi.fn();
+    hook(callback, 'arg1', 2).run();
+    expect(callback).toHaveBeenCalledWith('arg1', 2);
+  });
+
+  describe('ifEnabled', () => {
+    it('should run callback if the settings are enabled', () => {
+      mockSettings.set(SETTINGS.TEMPLATE_TARGET, true);
+      const callback = vi.fn();
+
+      hook(callback)
+        .ifEnabled(SETTINGS.TEMPLATE_TARGET)
+        .run();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run callback if any setting is disabled', () => {
+      mockSettings.set(SETTINGS.TEMPLATE_TARGET, true);
+      mockSettings.set(SETTINGS.AUTO_PANACHE, false);
+      const callback = vi.fn();
+
+      hook(callback)
+        .ifEnabled(SETTINGS.TEMPLATE_TARGET, SETTINGS.AUTO_PANACHE)
+        .run();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ifGM', () => {
+    it('should run callback if user is GM', () => {
+      (game.user as { isGM: boolean }).isGM = true;
+      const callback = vi.fn();
+
+      hook(callback).ifGM().run();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run callback if user is not GM', () => {
+      (game.user as { isGM: boolean }).isGM = false;
+      const callback = vi.fn();
+
+      hook(callback).ifGM().run();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ifUser', () => {
+    it('should run callback if current user ID matches target user ID', () => {
+      const callback = vi.fn();
+
+      hook(callback).ifUser('current-user-id').run();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run callback if user ID does not match', () => {
+      const callback = vi.fn();
+
+      hook(callback).ifUser('different-user-id').run();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ifMessagePoster', () => {
+    it('should run callback if user matches message author', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        author: { id: 'current-user-id' }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessagePoster().run();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run callback if user does not match message author', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        author: { id: 'different-user-id' }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessagePoster().run();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ifMessagePosterAndActorOwner', () => {
+    it('should run if user is message author AND owns the actor', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        author: { id: 'current-user-id' },
+        actor: { isOwner: true }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessagePosterAndActorOwner().run();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run if user is author but does not own the actor', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        author: { id: 'current-user-id' },
+        actor: { isOwner: false }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessagePosterAndActorOwner().run();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ifV12', () => {
+    it('should run if version starts with 12.', () => {
+      (game as { version: string }).version = '12.328';
+      const callback = vi.fn();
+
+      hook(callback).ifV12().run();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run if version does not start with 12.', () => {
+      (game as { version: string }).version = '13.336';
+      const callback = vi.fn();
+
+      hook(callback).ifV12().run();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Chaining conditions', () => {
+    it('should run if all conditions in the chain are met', () => {
+      mockSettings.set(SETTINGS.TEMPLATE_TARGET, true);
+      (game.user as { isGM: boolean }).isGM = true;
+      const callback = vi.fn();
+
+      hook(callback)
+        .ifEnabled(SETTINGS.TEMPLATE_TARGET)
+        .ifGM()
+        .run();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run if any condition in the chain fails', () => {
+      mockSettings.set(SETTINGS.TEMPLATE_TARGET, true);
+      (game.user as { isGM: boolean }).isGM = false;
+      const callback = vi.fn();
+
+      hook(callback)
+        .ifEnabled(SETTINGS.TEMPLATE_TARGET)
+        .ifGM()
+        .run();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { hook } from '../src/hooks.ts';
+import { hook } from '../src/hookrunner.ts';
 import { SETTINGS } from '../src/settings.ts';
 import { ChatMessagePF2e, GamePF2e } from 'foundry-pf2e';
 
@@ -22,13 +22,21 @@ describe('HookRunner & hook helper', () => {
         isGM: false,
         id: 'current-user-id',
       },
+      users: [
+        { isGM: false, id: 'current-user-id' }
+      ],
       version: '13.336',
     } as unknown as GamePF2e;
   });
 
-  it('should run callback with correct args if no conditions specified', () => {
+  it('should throw if no semantic guards are configured and allowUnfilteredRun is not called', () => {
     const callback = vi.fn();
-    hook(callback, 'arg1', 2).run();
+    expect(() => hook(callback).run()).toThrowError(/HookRunner: You must add guards/);
+  });
+
+  it('should run callback with correct args if allowUnfilteredRun is called', () => {
+    const callback = vi.fn();
+    hook(callback, 'arg1', 2).allowUnfilteredRun().run();
     expect(callback).toHaveBeenCalledWith('arg1', 2);
   });
 
@@ -39,6 +47,7 @@ describe('HookRunner & hook helper', () => {
 
       hook(callback)
         .ifEnabled(SETTINGS.TEMPLATE_TARGET)
+        .allowUnfilteredRun()
         .run();
 
       expect(callback).toHaveBeenCalled();
@@ -51,6 +60,7 @@ describe('HookRunner & hook helper', () => {
 
       hook(callback)
         .ifEnabled(SETTINGS.TEMPLATE_TARGET, SETTINGS.AUTO_PANACHE)
+        .allowUnfilteredRun()
         .run();
 
       expect(callback).not.toHaveBeenCalled();
@@ -62,7 +72,7 @@ describe('HookRunner & hook helper', () => {
       (game.user as { isGM: boolean }).isGM = true;
       const callback = vi.fn();
 
-      hook(callback).ifGM().run();
+      hook(callback).ifGM().allowUnfilteredRun().run();
 
       expect(callback).toHaveBeenCalled();
     });
@@ -71,7 +81,7 @@ describe('HookRunner & hook helper', () => {
       (game.user as { isGM: boolean }).isGM = false;
       const callback = vi.fn();
 
-      hook(callback).ifGM().run();
+      hook(callback).ifGM().allowUnfilteredRun().run();
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -81,7 +91,7 @@ describe('HookRunner & hook helper', () => {
     it('should run callback if current user ID matches target user ID', () => {
       const callback = vi.fn();
 
-      hook(callback).ifUser('current-user-id').run();
+      hook(callback).ifUser('current-user-id').allowUnfilteredRun().run();
 
       expect(callback).toHaveBeenCalled();
     });
@@ -89,7 +99,7 @@ describe('HookRunner & hook helper', () => {
     it('should NOT run callback if user ID does not match', () => {
       const callback = vi.fn();
 
-      hook(callback).ifUser('different-user-id').run();
+      hook(callback).ifUser('different-user-id').allowUnfilteredRun().run();
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -102,7 +112,7 @@ describe('HookRunner & hook helper', () => {
         author: { id: 'current-user-id' }
       } as unknown as ChatMessagePF2e;
 
-      hook(callback, mockMessage).ifMessagePoster().run();
+      hook(callback, mockMessage).ifMessagePoster().allowUnfilteredRun().run();
 
       expect(callback).toHaveBeenCalled();
     });
@@ -113,7 +123,7 @@ describe('HookRunner & hook helper', () => {
         author: { id: 'different-user-id' }
       } as unknown as ChatMessagePF2e;
 
-      hook(callback, mockMessage).ifMessagePoster().run();
+      hook(callback, mockMessage).ifMessagePoster().allowUnfilteredRun().run();
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -127,7 +137,10 @@ describe('HookRunner & hook helper', () => {
         actor: { isOwner: true }
       } as unknown as ChatMessagePF2e;
 
-      hook(callback, mockMessage).ifMessagePosterAndActorOwner().run();
+      hook(callback, mockMessage)
+        .ifMessagePosterAndActorOwner()
+        .allowUnfilteredRun()
+        .run();
 
       expect(callback).toHaveBeenCalled();
     });
@@ -139,7 +152,10 @@ describe('HookRunner & hook helper', () => {
         actor: { isOwner: false }
       } as unknown as ChatMessagePF2e;
 
-      hook(callback, mockMessage).ifMessagePosterAndActorOwner().run();
+      hook(callback, mockMessage)
+        .ifMessagePosterAndActorOwner()
+        .allowUnfilteredRun()
+        .run();
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -150,7 +166,7 @@ describe('HookRunner & hook helper', () => {
       (game as { version: string }).version = '12.328';
       const callback = vi.fn();
 
-      hook(callback).ifV12().run();
+      hook(callback).ifV12().allowUnfilteredRun().run();
 
       expect(callback).toHaveBeenCalled();
     });
@@ -159,9 +175,392 @@ describe('HookRunner & hook helper', () => {
       (game as { version: string }).version = '13.336';
       const callback = vi.fn();
 
-      hook(callback).ifV12().run();
+      hook(callback).ifV12().allowUnfilteredRun().run();
 
       expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Semantic guards (isGuarded = true)', () => {
+    it('should satisfy isGuarded check with ifMessageOption', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        flags: {
+          pf2e: {
+            context: {
+              options: ['item:trait:bravado']
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessageOption('item:trait:bravado').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifNotMessageOption', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        flags: {
+          pf2e: {
+            context: {
+              options: ['some-other-option']
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifNotMessageOption('action:tumble-through').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifMessageOptionAny', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        flags: {
+          pf2e: {
+            context: {
+              options: ['origin:item:trait:unstable']
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage)
+        .ifMessageOptionAny('origin:item:trait:unstable', 'self:action:trait:unstable')
+        .run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifMessageItemSlug', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        item: { slug: 'imaginary-weapon' }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessageItemSlug('imaginary-weapon').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifMessageHasTarget', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        target: { actor: { id: 'target-id' } }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessageHasTarget().run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifTargetHasEffect', () => {
+      const callback = vi.fn();
+      const mockTargetActor = {
+        itemTypes: {
+          effect: [{ slug: 'spell-effect-mirror-image' }]
+        }
+      };
+      const mockMessage = {
+        target: { actor: mockTargetActor }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifTargetHasEffect('spell-effect-mirror-image').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifMessageOutcomeIn', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        flags: {
+          pf2e: {
+            context: {
+              outcome: 'success'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessageOutcomeIn('success', 'criticalSuccess').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifActorHasFeat', () => {
+      const callback = vi.fn();
+      const mockActor = {
+        itemTypes: {
+          feat: [{ slug: 'antagonize' }]
+        }
+      };
+      const mockMessage = {
+        actor: mockActor
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifActorHasFeat('antagonize').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifActorHasEffect', () => {
+      const callback = vi.fn();
+      const mockActor = {
+        items: [{ type: 'effect', slug: 'samioli-antagonized' }]
+      };
+      const mockMessage = {
+        actor: mockActor
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifActorHasEffect('samioli-antagonized').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifActorHasEffect when actor is passed directly', () => {
+      const callback = vi.fn();
+      const mockActor = {
+        documentName: 'Actor',
+        items: [{ type: 'effect', slug: 'samioli-antagonized' }]
+      };
+
+      hook(callback, mockActor).ifActorHasEffect('samioli-antagonized').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run if ifActorHasEffect slug does not match', () => {
+      const callback = vi.fn();
+      const mockActor = {
+        items: [{ type: 'effect', slug: 'different-effect' }]
+      };
+      const mockMessage = {
+        actor: mockActor
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifActorHasEffect('samioli-antagonized').run();
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifActorHasEffectWithSlugPrefix', () => {
+      const callback = vi.fn();
+      const mockActor = {
+        items: [{ type: 'effect', slug: 'sustaining-effect-wall-of-fire' }]
+      };
+      const mockMessage = {
+        actor: mockActor
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage)
+        .ifActorHasEffectWithSlugPrefix('sustaining-effect-')
+        .run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifActorHasCondition', () => {
+      const callback = vi.fn();
+      const mockActor = {
+        items: [{ type: 'condition', slug: 'frightened' }]
+      };
+      const mockMessage = {
+        actor: mockActor
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifActorHasCondition('frightened').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifActorHasEffectWithFlag', () => {
+      const callback = vi.fn();
+      const mockActor = {
+        items: [{
+          type: 'effect',
+          slug: 'effect-slug',
+          flags: {
+            'samioli-module': {
+              startOfTurnSpellUuid: 'uuid'
+            }
+          },
+          getFlag(scope: string, key: string) {
+            const self = this as { flags?: unknown };
+            const flagsRecord = self.flags as Record<string, Record<string, unknown> | undefined>;
+            return flagsRecord?.[scope]?.[key];
+          }
+        }]
+      };
+      const mockMessage = {
+        actor: mockActor
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage)
+        .ifActorHasEffectWithFlag('samioli-module', 'startOfTurnSpellUuid')
+        .run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifItemType', () => {
+      const callback = vi.fn();
+      const mockItem = {
+        documentName: 'Item',
+        type: 'effect',
+        slug: 'effect-slug',
+        system: {},
+      };
+
+      hook(callback, mockItem).ifItemType('effect').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifItemType when item is nested', () => {
+      const callback = vi.fn();
+      const mockItem = {
+        documentName: 'Item',
+        type: 'effect',
+        slug: 'effect-slug',
+        system: {},
+      };
+      const mockMessage = {
+        item: mockItem
+      };
+
+      hook(callback, mockMessage).ifItemType('effect').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifItemSlug', () => {
+      const callback = vi.fn();
+      const mockItem = {
+        documentName: 'Item',
+        type: 'effect',
+        slug: 'effect-slug',
+        system: {},
+      };
+
+      hook(callback, mockItem).ifItemSlug('effect-slug').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifItemSlugStartsWith', () => {
+      const callback = vi.fn();
+      const mockItem = {
+        documentName: 'Item',
+        type: 'effect',
+        slug: 'sustaining-effect-wall-of-fire',
+        system: {},
+      };
+
+      hook(callback, mockItem).ifItemSlugStartsWith('sustaining-effect-').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifTokenHasFlag', () => {
+      const callback = vi.fn();
+      const mockToken = {
+        documentName: 'Token',
+        type: 'Token',
+        getFlag: (scope: string, key: string) => {
+          if (scope === 'samioli-module' && key === 'ghostlyCarrierEffectUUID') {
+            return 'some-uuid';
+          }
+          return undefined;
+        }
+      };
+
+      hook(callback, mockToken)
+        .ifTokenHasFlag('samioli-module', 'ghostlyCarrierEffectUUID')
+        .run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifTokenHasFlag when placeable token is passed', () => {
+      const callback = vi.fn();
+      const mockTokenDocument = {
+        documentName: 'Token',
+        getFlag: (scope: string, key: string) => {
+          if (scope === 'samioli-module' && key === 'ghostlyCarrierEffectUUID') {
+            return 'some-uuid';
+          }
+          return undefined;
+        }
+      };
+      const mockPlaceableToken = {
+        document: mockTokenDocument
+      };
+
+      hook(callback, mockPlaceableToken)
+        .ifTokenHasFlag('samioli-module', 'ghostlyCarrierEffectUUID')
+        .run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifTokenHasFlag when token is nested', () => {
+      const callback = vi.fn();
+      const mockTokenDocument = {
+        documentName: 'Token',
+        getFlag: (scope: string, key: string) => {
+          if (scope === 'samioli-module' && key === 'ghostlyCarrierEffectUUID') {
+            return 'some-uuid';
+          }
+          return undefined;
+        }
+      };
+      const mockMessage = {
+        token: mockTokenDocument
+      };
+
+      hook(callback, mockMessage)
+        .ifTokenHasFlag('samioli-module', 'ghostlyCarrierEffectUUID')
+        .run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with ifSceneHasTemplateWithFlag', () => {
+      const callback = vi.fn();
+      (globalThis as unknown as { canvas: unknown }).canvas = {
+        templates: {
+          placeables: [
+            {
+              document: {
+                getFlag: (scope: string, key: string) => {
+                  if (scope === 'samioli-module' && key === 'isStartOfTurnSpell') {
+                    return true;
+                  }
+                  return undefined;
+                }
+              }
+            }
+          ]
+        }
+      };
+
+      hook(callback)
+        .ifSceneHasTemplateWithFlag('samioli-module', 'isStartOfTurnSpell')
+        .run();
+      expect(callback).toHaveBeenCalled();
+      
+      delete (globalThis as Record<string, unknown>).canvas;
+    });
+
+    it('should satisfy isGuarded check with ifMessageHasFlag', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        flags: {
+          'samioli-module': {
+            buttonSlug: 'some-slug'
+          }
+        },
+        getFlag(scope: string, key: string) {
+          const self = this as { flags?: unknown };
+          const flagsRecord = self.flags as
+            | Record<string, Record<string, unknown> | undefined>
+            | undefined;
+          return flagsRecord?.[scope]?.[key];
+        }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage)
+        .ifMessageHasFlag('samioli-module', 'buttonSlug')
+        .run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should satisfy isGuarded check with if predicate', () => {
+      const callback = vi.fn();
+      hook(callback).if(() => true).run();
+      expect(callback).toHaveBeenCalled();
     });
   });
 
@@ -174,6 +573,7 @@ describe('HookRunner & hook helper', () => {
       hook(callback)
         .ifEnabled(SETTINGS.TEMPLATE_TARGET)
         .ifGM()
+        .allowUnfilteredRun()
         .run();
 
       expect(callback).toHaveBeenCalled();
@@ -187,6 +587,7 @@ describe('HookRunner & hook helper', () => {
       hook(callback)
         .ifEnabled(SETTINGS.TEMPLATE_TARGET)
         .ifGM()
+        .allowUnfilteredRun()
         .run();
 
       expect(callback).not.toHaveBeenCalled();

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -181,6 +181,40 @@ describe('HookRunner & hook helper', () => {
     });
   });
 
+  describe('ifMessageType', () => {
+    it('should run callback if context type matches target type', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        flags: {
+          pf2e: {
+            context: {
+              type: 'attack-roll'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessageType('attack-roll').run();
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should NOT run callback if type does not match', () => {
+      const callback = vi.fn();
+      const mockMessage = {
+        flags: {
+          pf2e: {
+            context: {
+              type: 'damage-roll'
+            }
+          }
+        }
+      } as unknown as ChatMessagePF2e;
+
+      hook(callback, mockMessage).ifMessageType('attack-roll').run();
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Semantic guards (isGuarded = true)', () => {
     it('should satisfy isGuarded check with ifMessageOption', () => {
       const callback = vi.fn();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,32 @@
+import { vi } from 'vitest';
+import { GamePF2e } from 'foundry-pf2e';
+
+// Define global foundry mock
+(globalThis as unknown as { foundry: typeof foundry }).foundry = {
+  applications: {
+    api: {
+      DialogV2: class {},
+      ApplicationV2: class {},
+      HandlebarsApplicationMixin: (Base: unknown) => Base,
+    },
+    handlebars: {
+      renderTemplate: () => {},
+    },
+    ux: {
+      FormDataExtended: class {},
+    },
+  },
+} as unknown as typeof foundry;
+
+// Define global Hooks mock
+(globalThis as unknown as { Hooks: typeof Hooks }).Hooks = {
+  on: vi.fn(),
+  once: vi.fn(),
+} as unknown as typeof Hooks;
+
+// Define a minimal game mock so top-level code executing imports does not crash
+(globalThis as unknown as { game: GamePF2e }).game = {
+  modules: {
+    get: vi.fn().mockReturnValue({ active: true }),
+  },
+} as unknown as GamePF2e;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -16,6 +16,9 @@ import { GamePF2e } from 'foundry-pf2e';
       FormDataExtended: class {},
     },
   },
+  utils: {
+    deepClone: <T>(val: T): T => structuredClone(val),
+  },
 } as unknown as typeof foundry;
 
 // Define global Hooks mock

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*.test.ts']
+    include: ['tests/**/*.test.ts'],
+    setupFiles: ['./tests/setup.ts']
   }
 });


### PR DESCRIPTION
This changes the hook calls in `hooks.ts` to include checks so that the functions are only called when needed.

This makes it easier to see when code is being executed, and ensures that we are not unnecessarily running code on every hook, e.g.  on every chat message.

All HookRunner calls must now include these guard checks, unless called with `.allowUnfilteredRun()`.