### PR TITLE
Simplify chatbuttonhelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - HookRunner refactor
 - Fix to Boost Eidolon requiring a focus point to work
 - Updated flag retrieval to be consistent
+- Simplification of chatbuttonhelper
 
 ## [0.65.0] - 2026-06-14
 

--- a/src/actions/antagonize.ts
+++ b/src/actions/antagonize.ts
@@ -144,3 +144,11 @@ export async function removeAntagonizeEffect(tokenId: string, antagonizedEffectI
         logd(`Could not find the antagonized effect on the actor.`);  
     }  
 }
+
+export async function onRemoveAntagonizeClick(
+    _message: ChatMessagePF2e,
+    tokenId: string,
+    effectId: string
+) {
+    await removeAntagonizeEffect(tokenId, effectId);
+}

--- a/src/actions/snare.ts
+++ b/src/actions/snare.ts
@@ -131,7 +131,14 @@ async function createSnareTriggeredChatMessage(deployer: TokenDocumentPF2e, trig
     });
 }
 
-export async function addSnareToChatAndTarget(itemUuid: string, snareId: string, triggererTokenUuid: string, snareX: string, snareY: string) {
+export async function onTriggerSnareClick(
+    _message: ChatMessagePF2e,
+    itemUuid: string,
+    snareId: string,
+    triggererTokenUuid: string,
+    snareX: string,
+    snareY: string
+) {
     animateSnareTrigger(parseInt(snareX), parseInt(snareY));
 
     const item = fromUuidSync(itemUuid) as ConsumablePF2e;

--- a/src/chatbuttonhelper.ts
+++ b/src/chatbuttonhelper.ts
@@ -2,7 +2,7 @@ import { ActorPF2e, ChatMessagePF2e } from "foundry-pf2e";
 import { getOwnersFromActor, logd, MODULE_ID } from "./utils.ts";
 import { onRemoveFrightenedAndAntagonizeClick } from "./effects/frightened.ts";
 import { onRemoveAntagonizeClick } from "./actions/antagonize.ts";
-import { onClearPanacheClick } from "./effects/panache.ts";
+import { onRemovePanacheClick } from "./effects/panache.ts";
 import { onSustainSpellClick, onRemoveSummonClick } from "./sustain.ts";
 import { onExtendBoostEidolonClick } from "./spells/boosteidolon.ts";
 import { onTriggerSnareClick } from "./actions/snare.ts";
@@ -16,7 +16,7 @@ export type ButtonHandler = (
 const BUTTON_FUNCTION_MAPPINGS: Record<string, ButtonHandler> = {
     "remove-frightened-and-antagonize": onRemoveFrightenedAndAntagonizeClick,
     "remove-antagonize": onRemoveAntagonizeClick,
-    "remove-panache": onClearPanacheClick,
+    "remove-panache": onRemovePanacheClick,
     "sustain-spell": onSustainSpellClick,
     "remove-summon": onRemoveSummonClick,
     "extend-boost-eidolon": onExtendBoostEidolonClick,

--- a/src/chatbuttonhelper.ts
+++ b/src/chatbuttonhelper.ts
@@ -1,58 +1,66 @@
-import { ActorPF2e, ChatMessagePF2e } from "foundry-pf2e"
+import { ActorPF2e, ChatMessagePF2e } from "foundry-pf2e";
 import { getOwnersFromActor, logd, MODULE_ID } from "./utils.ts";
-import { removeFrightenedAndAntagonize } from "./effects/frightened.ts";
-import { removeAntagonizeEffect } from "./actions/antagonize.ts";
-import { onClearPanacheButtonClick } from "./effects/panache.ts";
-import { handleSustainSpell, handleRemoveSummon } from "./sustain.ts";
-import { extendBoostEidolon } from "./spells/boosteidolon.ts";
-import { addSnareToChatAndTarget } from "./actions/snare.ts";
-import { handleMirrorImageRoll } from "./spells/mirrorimage.ts";
+import { onRemoveFrightenedAndAntagonizeClick } from "./effects/frightened.ts";
+import { onRemoveAntagonizeClick } from "./actions/antagonize.ts";
+import { onClearPanacheClick } from "./effects/panache.ts";
+import { onSustainSpellClick, onRemoveSummonClick } from "./sustain.ts";
+import { onExtendBoostEidolonClick } from "./spells/boosteidolon.ts";
+import { onTriggerSnareClick } from "./actions/snare.ts";
+import { onRollMirrorImageClick } from "./spells/mirrorimage.ts";
 
-// Mapping of slug to function description.
-// Slug must match what is provided in the MessageSpec when calling createChatMessageWithButton
-// If takesMsg is true, the first parameter of the function must be a ChatMessagePF2e
-const BUTTON_FUNCTION_MAPPINGS: Record<string, ButtonFunctionDescription> = {
-    "remove-frightened-and-antagonize": { func: removeFrightenedAndAntagonize, takesMsg: false },
-    "remove-antagonize": { func: removeAntagonizeEffect, takesMsg: false },
-    "remove-panache": { func: onClearPanacheButtonClick, takesMsg: true },
-    "sustain-spell": { func: handleSustainSpell, takesMsg: false },
-    "remove-summon": { func: handleRemoveSummon, takesMsg: false },
-    "extend-boost-eidolon": { func: extendBoostEidolon, takesMsg: true },
-    "trigger-snare": { func: addSnareToChatAndTarget, takesMsg: false },
-    "roll-mirror-image": { func: handleMirrorImageRoll, takesMsg: true }
+export type ButtonHandler = (
+    message: ChatMessagePF2e,
+    ...params: string[]
+) => void | Promise<void>;
+
+const BUTTON_FUNCTION_MAPPINGS: Record<string, ButtonHandler> = {
+    "remove-frightened-and-antagonize": onRemoveFrightenedAndAntagonizeClick,
+    "remove-antagonize": onRemoveAntagonizeClick,
+    "remove-panache": onClearPanacheClick,
+    "sustain-spell": onSustainSpellClick,
+    "remove-summon": onRemoveSummonClick,
+    "extend-boost-eidolon": onExtendBoostEidolonClick,
+    "trigger-snare": onTriggerSnareClick,
+    "roll-mirror-image": onRollMirrorImageClick
 };
-
-type StringOnlyFuncDescription = {
-    func: (...args: string[]) => void;
-    takesMsg: false;
-};
-
-type MessageFuncDescription = {
-    func: (msg: ChatMessagePF2e, ...args: string[]) => void;
-    takesMsg: true;
-};
-
-type ButtonFunctionDescription = StringOnlyFuncDescription | MessageFuncDescription;
 
 type MessageSpec = {
-    slug: string,
-    actor: ActorPF2e,
-    content: string,
-    button_label: string,
-    flags?: Record<string, unknown>,
-    params?: string[],
-    gmOnly?: boolean
-}
+    slug: string;
+    actor: ActorPF2e;
+    content: string;
+    button_label: string;
+    flags?: Record<string, unknown>;
+    params?: string[];
+    gmOnly?: boolean;
+};
 
+/**
+ * Creates a chat message containing a clickable button.
+ * The slug must match a registered handler in BUTTON_FUNCTION_MAPPINGS.
+ * Handlers must take (message: ChatMessagePF2e, ...params: string[]).
+ * 
+ * @example
+ * createChatMessageWithButton({
+ *     slug: "remove-antagonize",
+ *     actor,
+ *     content: "Message text",
+ *     button_label: "Remove",
+ *     params: [tokenId, effectId]
+ * });
+ */
 export async function createChatMessageWithButton(spec: MessageSpec) {
-    const funcDesc = BUTTON_FUNCTION_MAPPINGS[spec.slug];
-    if (!funcDesc) {
-        throw new Error(`Button slug ${spec.slug} has no function mapping.`);
+    const handler = BUTTON_FUNCTION_MAPPINGS[spec.slug];
+    if (!handler) {
+        throw new Error(`[samioli-module] Button slug ${spec.slug} has no function mapping.`);
     }
-    const params = spec.params ?? [];
-    const expectedParams = getNumberOfStringParams(funcDesc);
-    if (params.length !== expectedParams) {
-        throw new Error("Number of params provided does not match function inputs");
+
+    const expectedParamCount = Math.max(0, handler.length - 1);
+    const actualParamCount = spec.params?.length ?? 0;
+    if (actualParamCount !== expectedParamCount) {
+        throw new Error(
+            `[samioli-module] Slug "${spec.slug}" expects ${expectedParamCount} ` +
+            `parameters, but received ${actualParamCount}.`
+        );
     }
 
     const gms = game.users.filter(user => user.isGM).map(user => user.id);
@@ -73,8 +81,8 @@ export async function createChatMessageWithButton(spec: MessageSpec) {
 export function addButtonClickHandlers(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
     const slug = message.flags[MODULE_ID]?.buttonSlug as string | undefined;
     if (!slug) return;
-    const funcDesc = BUTTON_FUNCTION_MAPPINGS[slug];
-    if (!funcDesc) {
+    const handler = BUTTON_FUNCTION_MAPPINGS[slug];
+    if (!handler) {
         logd(`Button slug ${slug} has no function mapping.`);
         return;
     }
@@ -82,16 +90,9 @@ export function addButtonClickHandlers(message: ChatMessagePF2e, html: JQuery<HT
     const button = html.find(`button[id="${slug}"]`);
     if (button.length > 0) {
         button.on('click', () => {
-            const params: string[] = [];
-            const numParams = getNumberOfStringParams(funcDesc);
-            for (let i = 0; i < numParams; i++) {
-                params.push(button.data(`param${i}`));
-            }
-            if (funcDesc.takesMsg) {
-                funcDesc.func(message, ...params);
-            } else {
-                funcDesc.func(...params);
-            }
+            const paramsAttr = button.attr("data-params") ?? "[]";
+            const params = JSON.parse(paramsAttr) as string[];
+            handler(message, ...params);
         });
     }
 }
@@ -101,16 +102,11 @@ function buildMessageContent(spec: MessageSpec) {
         `<div style="display: flex; justify-content: center; gap: 10px; margin-top: 10px;">
         <button type="button" id="${spec.slug}"`;
 
-    if (spec.params) {
-        for (let i = 0; i < spec.params.length; i++) {
-            result += ` data-param${i}="${spec.params[i]}"`;
-        }
+    if (spec.params && spec.params.length > 0) {
+        const escapedParams = JSON.stringify(spec.params).replace(/"/g, "&quot;");
+        result += ` data-params="${escapedParams}"`;
     }
         
     result += `>${spec.button_label}</button></div>`;
     return result;
-}
-
-function getNumberOfStringParams(funcDesc: ButtonFunctionDescription) {
-    return funcDesc.takesMsg ? funcDesc.func.length - 1 : funcDesc.func.length;
 }

--- a/src/effects/frightened.ts
+++ b/src/effects/frightened.ts
@@ -1,4 +1,4 @@
-import { ActorPF2e, CombatantPF2e, ConditionPF2e, EffectPF2e, TokenPF2e } from "foundry-pf2e";
+import { ActorPF2e, ChatMessagePF2e, CombatantPF2e, ConditionPF2e, EffectPF2e, TokenPF2e } from "foundry-pf2e";
 import { getOwnersFromActor, logd, sendBasicChatMessage, MODULE_ID } from "../utils.ts";
 import { getActorAntagonizedEffects, removeAntagonizeEffect } from "../actions/antagonize.ts";
 import { createChatMessageWithButton } from "../chatbuttonhelper.ts";
@@ -84,7 +84,12 @@ async function createFrightenedAndAntagonizeRemovalConfirmationChatMessage
     });
 }
 
-export async function removeFrightenedAndAntagonize(frightenedConditionId: string, tokenId: string, antagonizedEffectId: string) {
+export async function onRemoveFrightenedAndAntagonizeClick(
+    _message: ChatMessagePF2e,
+    frightenedConditionId: string,
+    tokenId: string,
+    antagonizedEffectId: string
+) {
     const token = canvas.scene?.tokens.get(tokenId)?.object
     const actor = token?.actor;
     if (!actor) return;

--- a/src/effects/frightened.ts
+++ b/src/effects/frightened.ts
@@ -90,7 +90,7 @@ export async function onRemoveFrightenedAndAntagonizeClick(
     tokenId: string,
     antagonizedEffectId: string
 ) {
-    const token = canvas.scene?.tokens.get(tokenId)?.object
+    const token = canvas.scene?.tokens.get(tokenId)?.object;
     const actor = token?.actor;
     if (!actor) return;
     await removeAntagonizeEffect(tokenId, antagonizedEffectId);  

--- a/src/effects/panache.ts
+++ b/src/effects/panache.ts
@@ -134,7 +134,7 @@ async function createRemovePanacheChatMessage(actor: ActorPF2e) {
     });
 }
 
-export function onClearPanacheClick(chatMessagePF2e: ChatMessagePF2e) {
+export function onRemovePanacheClick(chatMessagePF2e: ChatMessagePF2e) {
   const actor = chatMessagePF2e.actor;
   if (!actor) return;
   clearPanache(actor);

--- a/src/effects/panache.ts
+++ b/src/effects/panache.ts
@@ -134,7 +134,7 @@ async function createRemovePanacheChatMessage(actor: ActorPF2e) {
     });
 }
 
-export function onClearPanacheButtonClick(chatMessagePF2e: ChatMessagePF2e) {
+export function onClearPanacheClick(chatMessagePF2e: ChatMessagePF2e) {
   const actor = chatMessagePF2e.actor;
   if (!actor) return;
   clearPanache(actor);

--- a/src/spells/boosteidolon.ts
+++ b/src/spells/boosteidolon.ts
@@ -82,7 +82,7 @@ async function createBoostEidolonEffectOnActor(eidolonActor: ActorPF2e) {
     await eidolonActor.createEmbeddedDocuments("Item", [boostEidolonEffect.toObject()]);
 }
 
-export async function extendBoostEidolon(chatMessage: ChatMessagePF2e) {
+export async function onExtendBoostEidolonClick(chatMessage: ChatMessagePF2e) {
 
     const summonerActor = chatMessage.actor;
     if (!summonerActor || !isCharacter(summonerActor)) return;

--- a/src/spells/mirrorimage.ts
+++ b/src/spells/mirrorimage.ts
@@ -47,7 +47,7 @@ export async function resolveMirrorImageOnAttack(chatMessage: ChatMessagePF2e): 
     }
 }
 
-export async function handleMirrorImageRoll(
+export async function onRollMirrorImageClick(
     _message: ChatMessagePF2e,
     targetTokenId: string,
     outcome: string,

--- a/src/sustain.ts
+++ b/src/sustain.ts
@@ -105,7 +105,11 @@ function getActorSustainedEffects(actor: ActorPF2e) {
     return sustainedEffects;
 }
 
-export async function handleSustainSpell(actorId: string, effectSlug: string) {
+export async function onSustainSpellClick(
+    _message: ChatMessagePF2e,
+    actorId: string,
+    effectSlug: string
+) {
     const actor = game.actors.get(actorId);
     if (!actor || !actor.isOwner) {
         ui.notifications.warn("You do not have permission to sustain this spell.");
@@ -227,7 +231,10 @@ function getSummonedTokensFromCanvas(casterId: string) {
     return summons;
 }
 
-export async function handleRemoveSummon(casterId: string) {
+export async function onRemoveSummonClick(
+    _message: ChatMessagePF2e,
+    casterId: string
+) {
     if (typeof casterId !== "string" || !casterId) return;
 
     const summons = getSummonedTokensFromCanvas(casterId);

--- a/tests/chatbuttonhelper.test.ts
+++ b/tests/chatbuttonhelper.test.ts
@@ -1,0 +1,222 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { ActorPF2e, ChatMessagePF2e } from "foundry-pf2e";
+import {
+    createChatMessageWithButton,
+    addButtonClickHandlers
+} from "../src/chatbuttonhelper.ts";
+import { MODULE_ID } from "../src/utils.ts";
+import { onRemoveAntagonizeClick } from "../src/actions/antagonize.ts";
+
+vi.mock("../src/effects/frightened.ts", () => ({
+    onRemoveFrightenedAndAntagonizeClick: vi.fn((_a, _b, _c, _d) => {})
+}));
+vi.mock("../src/actions/antagonize.ts", () => ({
+    onRemoveAntagonizeClick: vi.fn((_a, _b, _c) => {})
+}));
+vi.mock("../src/effects/panache.ts", () => ({
+    onClearPanacheClick: vi.fn((_a) => {})
+}));
+vi.mock("../src/sustain.ts", () => ({
+    onSustainSpellClick: vi.fn((_a, _b, _c) => {}),
+    onRemoveSummonClick: vi.fn((_a, _b) => {})
+}));
+vi.mock("../src/spells/boosteidolon.ts", () => ({
+    onExtendBoostEidolonClick: vi.fn((_a) => {})
+}));
+vi.mock("../src/actions/snare.ts", () => ({
+    onTriggerSnareClick: vi.fn((_a, _b, _c, _d, _e, _f) => {})
+}));
+vi.mock("../src/spells/mirrorimage.ts", () => ({
+    onRollMirrorImageClick: vi.fn((_a, _b, _c, _d) => {})
+}));
+
+describe("chatbuttonhelper", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // Mock game global
+        (globalThis as unknown as { game: unknown }).game = {
+            users: [
+                { isGM: true, id: "gm-user-id" },
+                { isGM: false, id: "player-user-id" }
+            ]
+        };
+
+        // Mock ChatMessage global
+        (globalThis as unknown as { ChatMessage: unknown }).ChatMessage = {
+            create: vi.fn().mockResolvedValue({}),
+            getSpeaker: vi.fn().mockReturnValue({ actor: "speaker-actor-id" })
+        };
+    });
+
+    describe("createChatMessageWithButton", () => {
+        it("should create chat message when correct param count is passed", async () => {
+            const mockActor = {
+                id: "actor-id",
+                testUserPermission: vi.fn().mockReturnValue(true)
+            } as unknown as ActorPF2e;
+
+            // "remove-antagonize" expects 2 parameters (tokenId, effectId)
+            await createChatMessageWithButton({
+                slug: "remove-antagonize",
+                actor: mockActor,
+                content: "Content",
+                button_label: "Label",
+                params: ["token-1", "effect-2"]
+            });
+
+            expect(ChatMessage.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: expect.stringContaining(
+                        'data-params="[&quot;token-1&quot;,&quot;effect-2&quot;]"'
+                    ),
+                    flags: {
+                        [MODULE_ID]: {
+                            buttonSlug: "remove-antagonize"
+                        }
+                    }
+                })
+            );
+        });
+
+        it("should throw error for unregistered slug", async () => {
+            const mockActor = {} as unknown as ActorPF2e;
+
+            await expect(
+                createChatMessageWithButton({
+                    slug: "invalid-slug",
+                    actor: mockActor,
+                    content: "Content",
+                    button_label: "Label"
+                })
+            ).rejects.toThrow(
+                "[samioli-module] Button slug invalid-slug has no function mapping."
+            );
+        });
+
+        it("should throw error for incorrect parameter count", async () => {
+            const mockActor = {
+                testUserPermission: vi.fn().mockReturnValue(true)
+            } as unknown as ActorPF2e;
+
+            // "remove-antagonize" expects 2 parameters
+            await expect(
+                createChatMessageWithButton({
+                    slug: "remove-antagonize",
+                    actor: mockActor,
+                    content: "Content",
+                    button_label: "Label",
+                    params: ["only-one-param"]
+                })
+            ).rejects.toThrow(
+                '[samioli-module] Slug "remove-antagonize" expects 2 parameters, but received 1.'
+            );
+        });
+
+        it("should handle parameters containing single and double quotes safely", async () => {
+            const mockActor = {
+                id: "actor-id",
+                testUserPermission: vi.fn().mockReturnValue(true)
+            } as unknown as ActorPF2e;
+
+            await createChatMessageWithButton({
+                slug: "remove-antagonize",
+                actor: mockActor,
+                content: "Content",
+                button_label: "Label",
+                params: ["Sami's Eidolon", 'A "double" quote']
+            });
+
+            expect(ChatMessage.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: expect.stringContaining(
+                        'data-params="[&quot;Sami\'s Eidolon&quot;,' +
+                        '&quot;A \\&quot;double\\&quot; quote&quot;]"'
+                    )
+                })
+            );
+        });
+    });
+
+    describe("addButtonClickHandlers", () => {
+        it("should bind click handler and trigger function on click", () => {
+            const mockMessage = {
+                flags: {
+                    [MODULE_ID]: {
+                        buttonSlug: "remove-antagonize"
+                    }
+                }
+            } as unknown as ChatMessagePF2e;
+
+            const mockButton = {
+                length: 1,
+                on: vi.fn(),
+                attr: vi.fn().mockReturnValue(JSON.stringify(["token-1", "effect-2"]))
+            };
+            const mockHtml = {
+                find: vi.fn().mockReturnValue(mockButton)
+            } as unknown as JQuery<HTMLElement>;
+
+            addButtonClickHandlers(mockMessage, mockHtml);
+
+            expect(mockHtml.find).toHaveBeenCalledWith('button[id="remove-antagonize"]');
+            expect(mockButton.on).toHaveBeenCalledWith("click", expect.any(Function));
+
+            // Trigger the click callback
+            const clickCallback = (mockButton.on as vi.Mock).mock.calls[0][1];
+            clickCallback();
+
+            expect(onRemoveAntagonizeClick).toHaveBeenCalledWith(
+                mockMessage,
+                "token-1",
+                "effect-2"
+            );
+        });
+
+        it("should do nothing if message has no buttonSlug flag", () => {
+            const mockMessage = {
+                flags: {}
+            } as unknown as ChatMessagePF2e;
+
+            const mockHtml = {
+                find: vi.fn()
+            } as unknown as JQuery<HTMLElement>;
+
+            addButtonClickHandlers(mockMessage, mockHtml);
+
+            expect(mockHtml.find).not.toHaveBeenCalled();
+        });
+
+        it("should parse parameters containing quotes back to original values", () => {
+            const mockMessage = {
+                flags: {
+                    [MODULE_ID]: {
+                        buttonSlug: "remove-antagonize"
+                    }
+                }
+            } as unknown as ChatMessagePF2e;
+
+            const mockButton = {
+                length: 1,
+                on: vi.fn(),
+                attr: vi.fn().mockReturnValue(
+                    '["Sami\'s Eidolon","A \\"double\\" quote"]'
+                )
+            };
+            const mockHtml = {
+                find: vi.fn().mockReturnValue(mockButton)
+            } as unknown as JQuery<HTMLElement>;
+
+            addButtonClickHandlers(mockMessage, mockHtml);
+
+            const clickCallback = (mockButton.on as vi.Mock).mock.calls[0][1];
+            clickCallback();
+
+            expect(onRemoveAntagonizeClick).toHaveBeenCalledWith(
+                mockMessage,
+                "Sami's Eidolon",
+                'A "double" quote'
+            );
+        });
+    });
+});

--- a/tests/chatbuttonhelper.test.ts
+++ b/tests/chatbuttonhelper.test.ts
@@ -14,7 +14,7 @@ vi.mock("../src/actions/antagonize.ts", () => ({
     onRemoveAntagonizeClick: vi.fn((_a, _b, _c) => {})
 }));
 vi.mock("../src/effects/panache.ts", () => ({
-    onClearPanacheClick: vi.fn((_a) => {})
+    onRemovePanacheClick: vi.fn((_a) => {})
 }));
 vi.mock("../src/sustain.ts", () => ({
     onSustainSpellClick: vi.fn((_a, _b, _c) => {}),


### PR DESCRIPTION
Simplifies chatbuttonhelper, by making all the button handler functions take the chatMessage.

Also renames the button handler functions to match a naming convention of on[something]Click.

And adds tests.