### PR TITLE
Fix snare functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - HookRunner refactor
 - Fix to Boost Eidolon requiring a focus point to work
 - Updated flag retrieval to be consistent
+- Fix snares (broken after refactor)
 
 ## [0.65.0] - 2026-06-14
 

--- a/src/chatautobuttons.ts
+++ b/src/chatautobuttons.ts
@@ -143,7 +143,10 @@ export function canAddAutoButton(message: ChatMessagePF2e): boolean {
         if (AUTO_BUTTONS_ACTIONS[slug]) return true;
     }
     if (category) {
-        if (AUTO_SWAP_BUTTONS_CONSUMABLES[category]) return true;
+        const matchesCategory = Object.entries(AUTO_SWAP_BUTTONS_CONSUMABLES).some(
+            ([key, spec]) => (spec.matcher ?? key) === category
+        );
+        if (matchesCategory) return true;
     }
     return false;
 }


### PR DESCRIPTION
The auto button swap on snares was broken in the hook refactor. This fixes it by making sure that the "matcher" is checked against the category of the item.