### PR TITLE
Migrate to renderChatMessageHTML hook and remove jQuery usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix to Boost Eidolon requiring a focus point to work
 - Updated flag retrieval to be consistent
 - Simplification of chatbuttonhelper
+- Migrate to renderChatMessageHTML hook and remove jQuery usage
 
 ## [0.65.0] - 2026-06-14
 

--- a/src/actions/enjoytheshow.ts
+++ b/src/actions/enjoytheshow.ts
@@ -4,21 +4,26 @@ import { applyPanacheForOutcome } from "../effects/panache.ts";
 
 export function editEnjoyTheShowSkillRoll(
     chatMessagePF2e: ChatMessagePF2e,
-    html: JQuery<HTMLElement>
+    html: HTMLElement
 ) {
-    html.find('.inline-check.with-repost').attr('data-against', 'will');
+    const elementToClone = html.querySelector(".inline-check.with-repost");
+    if (!elementToClone) return;
+
+    elementToClone.setAttribute("data-against", "will");
     
     const actor = chatMessagePF2e.actor;
     const hasFeat = actor?.items.some(
         entry => entry.system.slug === "acrobatic-performer" && entry.type === "feat"
     );
     if (hasFeat) {
-        const elementToClone = html.find('.inline-check.with-repost');
-        const clonedElement = elementToClone.clone();
-        clonedElement.attr('data-pf2-check', 'acrobatics');
-        clonedElement.find('.label').text('Perform with Acrobatics');
+        const clonedElement = elementToClone.cloneNode(true) as HTMLElement;
+        clonedElement.setAttribute("data-pf2-check", "acrobatics");
+        const label = clonedElement.querySelector(".label");
+        if (label) {
+            label.textContent = "Perform with Acrobatics";
+        }
         elementToClone.after(clonedElement);
-        elementToClone.after(' or ');
+        elementToClone.after(" or ");
     }
 }
 

--- a/src/chatautobuttons.ts
+++ b/src/chatautobuttons.ts
@@ -152,7 +152,7 @@ export function canAddAutoButton(message: ChatMessagePF2e): boolean {
  * Checks a chat message for specific roll options (slugs or categories) 
  * and triggers the addition or swapping of custom UI buttons on the chat card.
  */
-export function addAutoButtonToMessage(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
+export function addAutoButtonToMessage(message: ChatMessagePF2e, html: HTMLElement) {
     const rollOptions = message.flags.pf2e.origin?.rollOptions;
     const token = message.token?.object;
     if (!rollOptions || !token) return;
@@ -173,7 +173,7 @@ export function addAutoButtonToMessage(message: ChatMessagePF2e, html: JQuery<HT
 }
 
 function addMatchingButtons(slug: string, mappings: Record<string, ButtonSpec>,
-    containerLookup: string, token: TokenPF2e, message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
+    containerLookup: string, token: TokenPF2e, message: ChatMessagePF2e, html: HTMLElement) {
     for (const [key, buttonSpec] of Object.entries(mappings)) {
         const matcher = buttonSpec.matcher ?? key;
         
@@ -181,12 +181,14 @@ function addMatchingButtons(slug: string, mappings: Record<string, ButtonSpec>,
             continue;
         }
 
-        const button = $(`<button type="button">${buttonSpec.label}</button>`);
-        button.on("click", () => buttonSpec.function(token, message));
+        const button = document.createElement("button");
+        button.type = "button";
+        button.textContent = buttonSpec.label;
+        button.addEventListener("click", () => buttonSpec.function(token, message));
 
         // If the target container exists, place the new button at the end of it
-        const targetContainer = html.find(containerLookup);
-        if (targetContainer.length > 0) {
+        const targetContainer = html.querySelector(containerLookup);
+        if (targetContainer) {
             targetContainer.after(button);
         }
     }
@@ -198,7 +200,7 @@ function addMatchingButtons(slug: string, mappings: Record<string, ButtonSpec>,
  */
 function swapButtons(slug: string, mappings: Record<string, ButtonSwapSpec>,
     divLookup: string, token: TokenPF2e,
-    message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
+    message: ChatMessagePF2e, html: HTMLElement) {
     for (const [key, buttonSpec] of Object.entries(mappings)) {
         const matcher = buttonSpec.matcher ?? key;
 
@@ -207,10 +209,16 @@ function swapButtons(slug: string, mappings: Record<string, ButtonSwapSpec>,
         }
 
         const buttonDataAction = buttonSpec.buttonToReplace!;
-        const templateButton = html.find(buttonDataAction);
+        const templateButton = html.querySelector(buttonDataAction);
+        if (!templateButton) continue;
         const parentDiv = templateButton.closest(`div${divLookup}`);
-        const button = $(`<button type="button">${buttonSpec.label}</button>`);
-        button.on("click", () => buttonSpec.function(token, message));
+        if (!parentDiv) continue;
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.textContent = buttonSpec.label;
+        button.addEventListener("click", () => buttonSpec.function(token, message));
+        
         parentDiv.after(button);
         parentDiv.remove();
     }

--- a/src/chatbuttonhelper.ts
+++ b/src/chatbuttonhelper.ts
@@ -78,7 +78,7 @@ export async function createChatMessageWithButton(spec: MessageSpec) {
     });
 }
 
-export function addButtonClickHandlers(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
+export function addButtonClickHandlers(message: ChatMessagePF2e, html: HTMLElement) {
     const slug = message.flags[MODULE_ID]?.buttonSlug as string | undefined;
     if (!slug) return;
     const handler = BUTTON_FUNCTION_MAPPINGS[slug];
@@ -87,10 +87,10 @@ export function addButtonClickHandlers(message: ChatMessagePF2e, html: JQuery<HT
         return;
     }
  
-    const button = html.find(`button[id="${slug}"]`);
-    if (button.length > 0) {
-        button.on('click', () => {
-            const paramsAttr = button.attr("data-params") ?? "[]";
+    const button = html.querySelector(`button[id="${slug}"]`) as HTMLButtonElement | null;
+    if (button) {
+        button.addEventListener("click", () => {
+            const paramsAttr = button.getAttribute("data-params") ?? "[]";
             const params = JSON.parse(paramsAttr) as string[];
             handler(message, ...params);
         });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -97,25 +97,31 @@ Hooks.once("socketlib.ready", () => {
     registerSocket();
 });
 
-Hooks.on("renderChatMessage", async (message: ChatMessagePF2e, html: JQuery<HTMLElement>) => {
-    hook(addAutoButtonToMessage, message, html)
-        .if(() => canAddAutoButton(message))
-        .run();
-    hook(editEnjoyTheShowSkillRoll, message, html)
-        .ifMessageOption("origin:item:slug:enjoy-the-show")
-        .run();
-    hook(addButtonClickHandlers, message, html)
-        .ifMessageHasFlag(MODULE_ID, "buttonSlug")
-        .run();
-    hook(replaceUnstableCheckWithStrainCheck, message, html)
-        .ifEnabled(SETTINGS.UNSTABLE_CHECK_HOMEBREW)
-        .ifMessageOptionAny("origin:item:trait:unstable", "self:action:trait:unstable")
-        .run();
-    hook(addDancingBladeDamageButtons, message, html)
-        .ifMessageType("attack-roll")
-        .ifMessageOption("samioli-module:dancing-blade-attack")
-        .run();
-});
+Hooks.on(
+    "renderChatMessageHTML",
+    async (message: ChatMessagePF2e, html: HTMLElement) => {
+        hook(addAutoButtonToMessage, message, html)
+            .if(() => canAddAutoButton(message))
+            .run();
+        hook(editEnjoyTheShowSkillRoll, message, html)
+            .ifMessageOption("origin:item:slug:enjoy-the-show")
+            .run();
+        hook(addButtonClickHandlers, message, html)
+            .ifMessageHasFlag(MODULE_ID, "buttonSlug")
+            .run();
+        hook(replaceUnstableCheckWithStrainCheck, message, html)
+            .ifEnabled(SETTINGS.UNSTABLE_CHECK_HOMEBREW)
+            .ifMessageOptionAny(
+                "origin:item:trait:unstable",
+                "self:action:trait:unstable"
+            )
+            .run();
+        hook(addDancingBladeDamageButtons, message, html)
+            .ifMessageType("attack-roll")
+            .ifMessageOption("samioli-module:dancing-blade-attack")
+            .run();
+    }
+);
 
 Hooks.on("createMeasuredTemplate", async (
     template: MeasuredTemplateDocumentPF2e,

--- a/src/spells/dancingblade-anim.ts
+++ b/src/spells/dancingblade-anim.ts
@@ -413,26 +413,33 @@ async function startCrosshairsTargetSelection(token: TokenPF2e, range: number) {
 /**
  * Injects Damage and Critical buttons into the attack roll card footer.
  */
-export function addDancingBladeDamageButtons(message: ChatMessagePF2e, html: JQuery<HTMLElement>) {
-    const damageButton = $('<button type="button" data-action="damage">Damage</button>');
-    const criticalButton = $('<button type="button" data-action="critical">Critical</button>');
-
-    damageButton.on("click", (e) => {
+export function addDancingBladeDamageButtons(message: ChatMessagePF2e, html: HTMLElement) {
+    const damageButton = document.createElement("button");
+    damageButton.type = "button";
+    damageButton.setAttribute("data-action", "damage");
+    damageButton.textContent = "Damage";
+    damageButton.addEventListener("click", (e) => {
         e.stopPropagation();
         rollDancingBladeDamage(message, false);
     });
-    criticalButton.on("click", (e) => {
+
+    const criticalButton = document.createElement("button");
+    criticalButton.type = "button";
+    criticalButton.setAttribute("data-action", "critical");
+    criticalButton.textContent = "Critical";
+    criticalButton.addEventListener("click", (e) => {
         e.stopPropagation();
         rollDancingBladeDamage(message, true);
     });
 
-    const buttonContainer = $(`
-        <div class="card-buttons flexrow" style="gap: 5px; margin-top: 4px;" />
-    `);
+    const buttonContainer = document.createElement("div");
+    buttonContainer.className = "card-buttons flexrow";
+    buttonContainer.style.gap = "5px";
+    buttonContainer.style.marginTop = "4px";
     buttonContainer.append(damageButton, criticalButton);
 
-    const footer = html.find("footer");
-    if (footer.length > 0) {
+    const footer = html.querySelector("footer");
+    if (footer) {
         footer.before(buttonContainer);
     } else {
         html.append(buttonContainer);

--- a/src/unstablehomebrew.ts
+++ b/src/unstablehomebrew.ts
@@ -5,21 +5,23 @@ import { replaceTargets } from "./templatetarget.ts";
 
 export function replaceUnstableCheckWithStrainCheck(
     chatMessage: ChatMessagePF2e,
-    html: JQuery<HTMLElement>
+    html: HTMLElement
 ) {
-    const flatCheckLink = html.find('a.inline-check[data-pf2-dc="15"][data-pf2-check="flat"]');
-    if (!flatCheckLink.length) return;
+    const flatCheckLink = html.querySelector(
+        'a.inline-check[data-pf2-dc="15"][data-pf2-check="flat"]'
+    );
+    if (!flatCheckLink) return;
     const actor = chatMessage.actor;
     if (!actor) return;
     const strainDC = getStrainDC(actor);
 
-    const button = $(
-        `<a class="inline-check unstable-action-button">` +
+    const button = document.createElement("a");
+    button.className = "inline-check unstable-action-button";
+    button.innerHTML =
         `<i class="fa-solid fa-screwdriver-wrench"></i> ` +
-        `Strain Check DC ${strainDC}</a>`
-    );
+        `Strain Check DC ${strainDC}`;
 
-    button.on("click", async () => {
+    button.addEventListener("click", async () => {
         rollAgainstStrainDC(actor);
     });
 
@@ -96,13 +98,13 @@ async function createFireDamageChatMessage(actor: ActorPF2e) {
     });
 
     const hookFunction = async (chatMessage: ChatMessagePF2e) => {
-        if (chatMessage.flags["samioli-module"]?.unstableCheckCriticalFailure){
+        if (chatMessage.flags["samioli-module"]?.unstableCheckCriticalFailure) {
             await replaceTargets([...currentTargets.map(t => t.id)]);
-            Hooks.off("renderChatMessage", hookFunction);
+            Hooks.off("renderChatMessageHTML", hookFunction);
         }
     };
 
-    Hooks.on("renderChatMessage", hookFunction);
+    Hooks.on("renderChatMessageHTML", hookFunction);
 }
 
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -174,12 +174,12 @@ export function returnStringOfNamesFromArray(names: string[]): string {
     return `${allButLast} and ${last}`;
 }
 
-export function getHtmlElement(htmlOrJquery: JQuery | HTMLElement) {
-    if (htmlOrJquery instanceof jQuery) {
-        return (htmlOrJquery as JQuery)[0] as HTMLElement;
+export function getHtmlElement(htmlOrJquery: JQuery | HTMLElement): HTMLElement {
+    if (htmlOrJquery instanceof HTMLElement) {
+        return htmlOrJquery;
     }
-    // Otherwise, it's HTML, just return it
-    return htmlOrJquery as HTMLElement;
+    // If it is a jQuery object, return the first wrapped element
+    return (htmlOrJquery as JQuery)[0] as HTMLElement;
 }
 
 export function getEnemyTokensFromTokenArray(self: TokenPF2e, tokens: TokenPF2e[]): TokenPF2e[] {

--- a/tests/chatbuttonhelper.test.ts
+++ b/tests/chatbuttonhelper.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, Mock } from "vitest";
 import { ActorPF2e, ChatMessagePF2e } from "foundry-pf2e";
 import {
     createChatMessageWithButton,
@@ -149,21 +149,29 @@ describe("chatbuttonhelper", () => {
             } as unknown as ChatMessagePF2e;
 
             const mockButton = {
-                length: 1,
-                on: vi.fn(),
-                attr: vi.fn().mockReturnValue(JSON.stringify(["token-1", "effect-2"]))
-            };
+                addEventListener: vi.fn(),
+                getAttribute: vi.fn().mockReturnValue(
+                    JSON.stringify(["token-1", "effect-2"])
+                )
+            } as unknown as HTMLButtonElement;
             const mockHtml = {
-                find: vi.fn().mockReturnValue(mockButton)
-            } as unknown as JQuery<HTMLElement>;
+                querySelector: vi.fn().mockReturnValue(mockButton)
+            } as unknown as HTMLElement;
 
             addButtonClickHandlers(mockMessage, mockHtml);
 
-            expect(mockHtml.find).toHaveBeenCalledWith('button[id="remove-antagonize"]');
-            expect(mockButton.on).toHaveBeenCalledWith("click", expect.any(Function));
+            expect(mockHtml.querySelector).toHaveBeenCalledWith(
+                'button[id="remove-antagonize"]'
+            );
+            expect(mockButton.addEventListener).toHaveBeenCalledWith(
+                "click",
+                expect.any(Function)
+            );
 
             // Trigger the click callback
-            const clickCallback = (mockButton.on as vi.Mock).mock.calls[0][1];
+            const clickCallback = (
+                mockButton.addEventListener as Mock
+            ).mock.calls[0][1];
             clickCallback();
 
             expect(onRemoveAntagonizeClick).toHaveBeenCalledWith(
@@ -179,12 +187,12 @@ describe("chatbuttonhelper", () => {
             } as unknown as ChatMessagePF2e;
 
             const mockHtml = {
-                find: vi.fn()
-            } as unknown as JQuery<HTMLElement>;
+                querySelector: vi.fn()
+            } as unknown as HTMLElement;
 
             addButtonClickHandlers(mockMessage, mockHtml);
 
-            expect(mockHtml.find).not.toHaveBeenCalled();
+            expect(mockHtml.querySelector).not.toHaveBeenCalled();
         });
 
         it("should parse parameters containing quotes back to original values", () => {
@@ -197,19 +205,20 @@ describe("chatbuttonhelper", () => {
             } as unknown as ChatMessagePF2e;
 
             const mockButton = {
-                length: 1,
-                on: vi.fn(),
-                attr: vi.fn().mockReturnValue(
+                addEventListener: vi.fn(),
+                getAttribute: vi.fn().mockReturnValue(
                     '["Sami\'s Eidolon","A \\"double\\" quote"]'
                 )
-            };
+            } as unknown as HTMLButtonElement;
             const mockHtml = {
-                find: vi.fn().mockReturnValue(mockButton)
-            } as unknown as JQuery<HTMLElement>;
+                querySelector: vi.fn().mockReturnValue(mockButton)
+            } as unknown as HTMLElement;
 
             addButtonClickHandlers(mockMessage, mockHtml);
 
-            const clickCallback = (mockButton.on as vi.Mock).mock.calls[0][1];
+            const clickCallback = (
+                mockButton.addEventListener as Mock
+            ).mock.calls[0][1];
             clickCallback();
 
             expect(onRemoveAntagonizeClick).toHaveBeenCalledWith(


### PR DESCRIPTION
Moves away from the old jQuery based chat message hook to the newer HTML-based one.

This fixes warnings saying the following:

```
foundry.mjs:6727 Error: The renderChatMessage hook is deprecated. Please use renderChatMessageHTML instead, which now passes an HTMLElement argument instead of jQuery.
Deprecated since Version 13
Backwards-compatible support will be removed in Version 15
```