### PR TITLE
[autorelease] Release 0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.66.0] - 2026-08-04
+
 - HookRunner refactor
 - Fix to Boost Eidolon requiring a focus point to work
 - Updated flag retrieval to be consistent
@@ -132,7 +134,9 @@
 - Notification instructions shown for Dive and Breach
 - Switch to typescript
 
-[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.65.0...HEAD
+[Unreleased]: https://github.com/olilan1/samioli-module/compare/v0.66.0...HEAD
+
+[0.66.0]: https://github.com/olilan1/samioli-module/compare/v0.65.0...v0.66.0
 
 [0.65.0]: https://github.com/olilan1/samioli-module/compare/v0.64.0...v0.65.0
 


### PR DESCRIPTION
**This PR was created automatically by the releasebot**

**:warning: Approving this PR will trigger a workflow that generates a draft release. You need to publish this release when you are happy with it.**

The changes in this PR prepare for release 0.66.0. The release notes are:

---

- HookRunner refactor
- Fix to Boost Eidolon requiring a focus point to work
- Updated flag retrieval to be consistent
- Fix snares (broken after refactor)
- Simplification of chatbuttonhelper
- Migrate to renderChatMessageHTML hook and remove jQuery usage
- Sustain bug fix when initiative is shared